### PR TITLE
fix toboxInfo struct type

### DIFF
--- a/pkg/debrid/structs/torbox.go
+++ b/pkg/debrid/structs/torbox.go
@@ -34,7 +34,7 @@ type torboxInfo struct {
 	DownloadState   string      `json:"download_state"`
 	Seeds           int         `json:"seeds"`
 	Peers           int         `json:"peers"`
-	Ratio           int         `json:"ratio"`
+	Ratio           float64     `json:"ratio"`
 	Progress        float64     `json:"progress"`
 	DownloadSpeed   int         `json:"download_speed"`
 	UploadSpeed     int         `json:"upload_speed"`


### PR DESCRIPTION
Fix issue where sometimes with knaben indexer a type mismatch is created by the field ratio or torboxInfo struct