### PR TITLE
Magnet link handler

### DIFF
--- a/pkg/qbit/server/templates/config.html
+++ b/pkg/qbit/server/templates/config.html
@@ -75,7 +75,7 @@
                     </div>
 
                     <!-- Repair Configuration -->
-                    <div class="section">
+                    <div class="section mb-5">
                         <h5 class="border-bottom pb-2">Repair Configuration</h5>
                         <div class="row">
                             <div class="col-md-6 mb-3">
@@ -92,6 +92,13 @@
                                     <label class="form-check-label" for="repairOnStart">Run on Start</label>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+
+                    <!-- Register Magnet Link Button -->
+                    <div class="section">
+                        <div class="btn btn-primary" onclick="registerMagnetLinkHandler()">
+                            Register Magnet Link Handler
                         </div>
                     </div>
                 </form>
@@ -306,5 +313,32 @@
                 arrCount++;
             }
         });
+
+
+        // Register magnet link handler
+        function registerMagnetLinkHandler() {
+            if ('registerProtocolHandler' in navigator) {
+                try {
+                    navigator.registerProtocolHandler(
+                        'magnet',
+                        `${window.location.origin}/download?magnet=%s`,
+                        'DecyphArr'
+                    );
+                    console.log('Registered magnet link handler successfully.');
+                } catch (error) {
+                    console.error('Failed to register magnet link handler:', error);
+                }
+            }
+
+            // Handle incoming magnet links
+            const urlParams = new URLSearchParams(window.location.search);
+            const magnetLink = urlParams.get('magnet');
+
+            if (magnetLink) {
+                console.log('Received Magnet Link:', magnetLink);
+                // Add logic to handle the magnet link (e.g., start the download)
+                alert(`Magnet Link Received: ${magnetLink}`);
+            }
+        }
     </script>
 {{ end }}

--- a/pkg/qbit/server/templates/config.html
+++ b/pkg/qbit/server/templates/config.html
@@ -21,6 +21,15 @@
                                 </select>
                             </div>
                             </div>
+                            <!-- Register Magnet Link Button -->
+                             <div class="col-md-6">
+                                <label>
+                                    <!-- Empty label to keep the button aligned -->
+                                </label>
+                                <div class="btn btn-primary w-100" onclick="registerMagnetLinkHandler()">
+                                    Register Magnet Link Handler
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <!-- Debrid Configuration -->
@@ -92,13 +101,6 @@
                                     <label class="form-check-label" for="repairOnStart">Run on Start</label>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-
-                    <!-- Register Magnet Link Button -->
-                    <div class="section">
-                        <div class="btn btn-primary" onclick="registerMagnetLinkHandler()">
-                            Register Magnet Link Handler
                         </div>
                     </div>
                 </form>

--- a/pkg/qbit/server/templates/config.html
+++ b/pkg/qbit/server/templates/config.html
@@ -329,16 +329,6 @@
                     console.error('Failed to register magnet link handler:', error);
                 }
             }
-
-            // Handle incoming magnet links
-            const urlParams = new URLSearchParams(window.location.search);
-            const magnetLink = urlParams.get('magnet');
-
-            if (magnetLink) {
-                console.log('Received Magnet Link:', magnetLink);
-                // Add logic to handle the magnet link (e.g., start the download)
-                alert(`Magnet Link Received: ${magnetLink}`);
-            }
         }
     </script>
 {{ end }}

--- a/pkg/qbit/server/templates/config.html
+++ b/pkg/qbit/server/templates/config.html
@@ -27,7 +27,7 @@
                                     <!-- Empty label to keep the button aligned -->
                                 </label>
                                 <div class="btn btn-primary w-100" onclick="registerMagnetLinkHandler()">
-                                    Register Magnet Link Handler
+                                    Open Magnet Links in DecyphArr
                                 </div>
                             </div>
                         </div>

--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -69,6 +69,19 @@
                     submitBtn.innerHTML = originalText;
                 }
             });
+
+            // Read the URL parameters for a magnet link and add it to the download queue if found
+            const urlParams = new URLSearchParams(window.location.search);
+            const magnetURI = urlParams.get('magnet');
+            if (magnetURI) {
+                document.getElementById('magnetURI').value = magnetURI;
+                try {
+                    document.getElementById('submitDownload').click();
+                    history.replaceState({}, document.title, window.location.pathname);
+                } catch (error) {
+                    console.error('Error adding download:', error);
+                }
+            }
         });
     </script>
 {{ end }}


### PR DESCRIPTION
This PR implements a basic magnet link handler so users can register Decypharr as a torrent client in their browsers. Here's a video of the process:

https://github.com/user-attachments/assets/9e6aff92-a8f3-4540-83ae-08919ee9d251

**What's new:**

- A "Register Magnet Link Handler" button was added to the config page
- The download page now looks for a `magnet` URL param. If it exists, a download automatically starts (with no category)