### PR TITLE
Ability to upload torrent files

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -115,7 +115,11 @@ func OpenMagnetHttpURL(magnetLink string) (*Magnet, error) {
 			return
 		}
 	}(resp) // Ensure the response is closed after the function ends
-	return GetMagnetFromFile(resp.Body, magnetLink)
+	torrentData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+	return GetMagnetFromBytes(torrentData)
 }
 
 func GetMagnetInfo(magnetLink string) (*Magnet, error) {

--- a/common/utils.go
+++ b/common/utils.go
@@ -30,23 +30,11 @@ type Magnet struct {
 
 func GetMagnetFromFile(file io.Reader, filePath string) (*Magnet, error) {
 	if filepath.Ext(filePath) == ".torrent" {
-		mi, err := metainfo.Load(file)
+		torrentData, err := io.ReadAll(file)
 		if err != nil {
 			return nil, err
 		}
-		hash := mi.HashInfoBytes()
-		infoHash := hash.HexString()
-		info, err := mi.UnmarshalInfo()
-		if err != nil {
-			return nil, err
-		}
-		magnet := &Magnet{
-			InfoHash: infoHash,
-			Name:     info.Name,
-			Size:     info.Length,
-			Link:     mi.Magnet(&hash, &info).String(),
-		}
-		return magnet, nil
+		return GetMagnetFromBytes(torrentData)
 	} else {
 		// .magnet file
 		magnetLink := ReadMagnetFile(file)

--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -5,20 +5,25 @@
                 <h4 class="mb-0"><i class="bi bi-cloud-download me-2"></i>Add New Download</h4>
             </div>
             <div class="card-body">
-                <form id="downloadForm">
+                <form id="downloadForm" enctype="multipart/form-data">
                     <div class="mb-3">
                         <label for="magnetURI" class="form-label">Magnet Link(s) or Torrent URL(s)</label>
-                        <textarea class="form-control" id="magnetURI" rows="8" placeholder="Paste your magnet links or torrent URLs here, one per line..."></textarea>
+                        <textarea class="form-control" id="magnetURI" name="urls" rows="8" placeholder="Paste your magnet links or torrent URLs here, one per line..."></textarea>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="torrentFiles" class="form-label">Torrent Files</label>
+                        <input type="file" class="form-control" id="torrentFiles" name="torrents" multiple accept=".torrent">
                     </div>
 
                     <div class="mb-3">
                         <label for="category" class="form-label">Enter Category</label>
-                        <input type="text" class="form-control" id="category" placeholder="Enter Category(e.g sonarr, radarr, radarr4k)">
+                        <input type="text" class="form-control" id="category" name="arr" placeholder="Enter Category (e.g sonarr, radarr, radarr4k)">
                     </div>
 
                     <div class="mb-3">
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="isSymlink">
+                            <input class="form-check-input" type="checkbox" id="isSymlink" name="notSymlink">
                             <label class="form-check-label" for="isSymlink">
                                 Download real files instead of symlinks
                             </label>
@@ -46,31 +51,40 @@
                 submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Adding...';
 
                 try {
+                    const formData = new FormData();
+                    
+                    // Add URLs if present
                     const urls = document.getElementById('magnetURI').value
                         .split('\n')
                         .map(url => url.trim())
                         .filter(url => url.length > 0);
 
-                    if (urls.length === 0) {
-                        alert('Please submit at least one torrent');
+                    if (urls.length > 0) {
+                        formData.append('urls', urls.join('\n'));
+                    }
+
+                    // Add torrent files if present
+                    const fileInput = document.getElementById('torrentFiles');
+                    for (let i = 0; i < fileInput.files.length; i++) {
+                        formData.append('torrents', fileInput.files[i]);
+                    }
+
+                    if (urls.length === 0 && fileInput.files.length === 0) {
+                        alert('Please submit at least one torrent or URL');
                         return;
                     }
+
                     if (urls.length >= 100) {
                         alert('Please submit less than 100 torrents at a time');
                         return;
                     }
 
+                    formData.append('arr', document.getElementById('category').value);
+                    formData.append('notSymlink', document.getElementById('isSymlink').checked);
 
                     const response = await fetch('/internal/add', {
                         method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify({
-                            urls: urls,
-                            arr: document.getElementById('category').value,
-                            notSymlink: document.getElementById('isSymlink').checked
-                        })
+                        body: formData
                     });
 
                     const result = await response.json();
@@ -82,6 +96,7 @@
                     }
 
                     document.getElementById('magnetURI').value = '';
+                    document.getElementById('torrentFiles').value = '';
                 } catch (error) {
                     alert(`Error adding downloads: ${error.message}`);
                 } finally {

--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -74,8 +74,8 @@
                         return;
                     }
 
-                    if (urls.length >= 100) {
-                        alert('Please submit less than 100 torrents at a time');
+                    if (urls.length + fileInput.files.length > 100) {
+                        alert('Please submit up to 100 downloads at a time');
                         return;
                     }
 

--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -6,14 +6,16 @@
             </div>
             <div class="card-body">
                 <form id="downloadForm" enctype="multipart/form-data">
-                    <div class="mb-3">
-                        <label for="magnetURI" class="form-label">Magnet Link(s) or Torrent URL(s)</label>
+                    <div class="mb-2">
+                        <label for="magnetURI" class="form-label">Torrent(s)</label>
                         <textarea class="form-control" id="magnetURI" name="urls" rows="8" placeholder="Paste your magnet links or torrent URLs here, one per line..."></textarea>
                     </div>
 
                     <div class="mb-3">
                         <input type="file" class="form-control" id="torrentFiles" name="torrents" multiple accept=".torrent,.magnet">
                     </div>
+
+                    <hr />
 
                     <div class="mb-3">
                         <label for="category" class="form-label">Enter Category</label>

--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -12,8 +12,7 @@
                     </div>
 
                     <div class="mb-3">
-                        <label for="torrentFiles" class="form-label">Torrent Files</label>
-                        <input type="file" class="form-control" id="torrentFiles" name="torrents" multiple accept=".torrent">
+                        <input type="file" class="form-control" id="torrentFiles" name="torrents" multiple accept=".torrent,.magnet">
                     </div>
 
                     <div class="mb-3">
@@ -66,7 +65,7 @@
                     // Add torrent files if present
                     const fileInput = document.getElementById('torrentFiles');
                     for (let i = 0; i < fileInput.files.length; i++) {
-                        formData.append('torrents', fileInput.files[i]);
+                        formData.append('files', fileInput.files[i]);
                     }
 
                     if (urls.length === 0 && fileInput.files.length === 0) {

--- a/pkg/qbit/server/ui_handlers.go
+++ b/pkg/qbit/server/ui_handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"net/http"
 	"strings"
 
@@ -118,37 +119,72 @@ func (u *uiHandler) handleGetArrs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (u *uiHandler) handleAddContent(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		URLs       []string `json:"urls"`
-		Arr        string   `json:"arr"`
-		NotSymlink bool     `json:"notSymlink"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	results := make([]*ImportRequest, 0, len(req.URLs))
+	results := make([]*ImportRequest, 0)
 	errs := make([]string, 0)
 
-	_arr := u.qbit.Arrs.Get(req.Arr)
+	arrName := r.FormValue("arr")
+	notSymlink := r.FormValue("notSymlink") == "true"
+
+	_arr := u.qbit.Arrs.Get(arrName)
 	if _arr == nil {
-		_arr = arr.NewArr(req.Arr, "", "", arr.Sonarr)
+		_arr = arr.NewArr(arrName, "", "", arr.Sonarr)
 	}
 
-	for _, url := range req.URLs {
-		if url == "" {
-			continue
+	// Handle URLs
+	if urls := r.FormValue("urls"); urls != "" {
+		var urlList []string
+		for _, u := range strings.Split(urls, "\n") {
+			if trimmed := strings.TrimSpace(u); trimmed != "" {
+				urlList = append(urlList, trimmed)
+			}
 		}
 
-		importReq := NewImportRequest(url, _arr, !req.NotSymlink)
-		err := importReq.Process(u.qbit)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("URL %s: %v", url, err))
-			continue
+		for _, url := range urlList {
+			importReq := NewImportRequest(url, _arr, !notSymlink)
+			err := importReq.Process(u.qbit)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("URL %s: %v", url, err))
+				continue
+			}
+			results = append(results, importReq)
 		}
-		results = append(results, importReq)
+	}
+
+	// Handle torrent files
+	if files := r.MultipartForm.File["torrents"]; len(files) > 0 {
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("Failed to open file %s: %v", fileHeader.Filename, err))
+				continue
+			}
+
+			torrentData, err := io.ReadAll(file)
+			file.Close()
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("Failed to read file %s: %v", fileHeader.Filename, err))
+				continue
+			}
+
+			magnet, err := common.GetMagnetFromBytes(torrentData)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("Failed to parse torrent file %s: %v", fileHeader.Filename, err))
+				continue
+			}
+
+			importReq := NewImportRequest(magnet.Link, _arr, !notSymlink)
+			err = importReq.Process(u.qbit)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("File %s: %v", fileHeader.Filename, err))
+				continue
+			}
+			results = append(results, importReq)
+		}
 	}
 
 	common.JSONResponse(w, struct {

--- a/pkg/qbit/server/ui_handlers.go
+++ b/pkg/qbit/server/ui_handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"net/http"
 	"strings"
 
@@ -155,8 +154,8 @@ func (u *uiHandler) handleAddContent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Handle torrent files
-	if files := r.MultipartForm.File["torrents"]; len(files) > 0 {
+	// Handle torrent/magnet files
+	if files := r.MultipartForm.File["files"]; len(files) > 0 {
 		for _, fileHeader := range files {
 			file, err := fileHeader.Open()
 			if err != nil {
@@ -164,14 +163,7 @@ func (u *uiHandler) handleAddContent(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			torrentData, err := io.ReadAll(file)
-			file.Close()
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("Failed to read file %s: %v", fileHeader.Filename, err))
-				continue
-			}
-
-			magnet, err := common.GetMagnetFromBytes(torrentData)
+			magnet, err := common.GetMagnetFromFile(file, fileHeader.Filename)
 			if err != nil {
 				errs = append(errs, fmt.Sprintf("Failed to parse torrent file %s: %v", fileHeader.Filename, err))
 				continue


### PR DESCRIPTION
**What's New**:

- Ability to upload torrent files (in tandem with magnet links and magnet URIs)
- The UI's `addTorrent` handler was reworked to accept form data instead of JSON data. This was necessary to allow for uploading files.

**Improvements**:

- Reused code in the functions that parse torrent files in `common/utils.go` have been abstracted into `GetMagnetFromBytes`
- Set the limit of batch download requests to 100 instead of 99 (aesthetic choice)
- Minor typo fix (missing space in "Enter Category(e.g sonarr, radarr, radarr4k)"

**Demo**:

https://github.com/user-attachments/assets/d545ec07-f3c2-4852-9e9c-eec7dee19465

