### PR TITLE
feat(cli): implement cli with health, serve and version commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,8 @@ EXPOSE 8181 8282
 
 VOLUME ["/app"]
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["/blackhole", "health", "--config", "/app/config.json"]
+
 # Run
-CMD ["/blackhole", "--config", "/app/config.json"]
+CMD ["/blackhole", "serve", "--config", "/app/config.json"]

--- a/main.go
+++ b/main.go
@@ -1,27 +1,16 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"github.com/sirrobot01/debrid-blackhole/cmd"
-	"github.com/sirrobot01/debrid-blackhole/common"
-	"log"
+	"fmt"
+	"os"
+
+	"github.com/sirrobot01/debrid-blackhole/pkg/cli"
+	_ "github.com/sirrobot01/debrid-blackhole/pkg/cli/commands"
 )
 
 func main() {
-	var configPath string
-	flag.StringVar(&configPath, "config", "config.json", "path to the config file")
-	flag.Parse()
-
-	// Load the config file
-	conf, err := common.LoadConfig(configPath)
-	common.CONFIG = conf
-	if err != nil {
-		log.Fatal(err)
+	if err := cli.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
-	ctx := context.Background()
-	if err := cmd.Start(ctx, conf); err != nil {
-		log.Fatal(err)
-	}
-
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+var commands = map[string]Command{}
+
+func Register(cmd Command) {
+    commands[cmd.Name] = cmd
+}
+
+func showUsage() {
+    fmt.Println("Usage: blackhole <command> [options]")
+    fmt.Println("\nAvailable Commands:")
+    for _, cmd := range commands {
+        fmt.Printf("  %-12s %s\n", cmd.Name, cmd.Description)
+    }
+    fmt.Println("\nUse 'blackhole <command> --help' for more information about a command")
+}
+
+func Execute() error {
+    if len(os.Args) < 2 {
+        showUsage()
+        return nil
+    }
+
+    commandName := os.Args[1]
+    command, exists := commands[commandName]
+    if !exists {
+        if commandName == "--help" || commandName == "-h" {
+            showUsage()
+            return nil
+        }
+        return fmt.Errorf("unknown command %q", commandName)
+    }
+
+    return command.Execute(os.Args[2:])
+}

--- a/pkg/cli/commands/health.go
+++ b/pkg/cli/commands/health.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/sirrobot01/debrid-blackhole/common"
+	"github.com/sirrobot01/debrid-blackhole/pkg/cli"
+)
+
+func init() {
+	cli.Register(cli.Command{
+		Name:        "health",
+		Description: "Check the health of the Blackhole server",
+		Execute:     executeHealth,
+	})
+}
+
+func executeHealth(args []string) error {
+	fs := flag.NewFlagSet("health", flag.ExitOnError)
+	configPath := fs.String("config", "/app/config.json", "path to config file")
+	timeout := fs.Duration("timeout", 3*time.Second, "timeout for health check")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	port := "8282"
+	if envPort := os.Getenv("QBIT_PORT"); envPort != "" {
+		port = envPort
+	} else {
+		conf, err := common.LoadConfig(*configPath)
+		if err == nil && conf.QBitTorrent.Port != "" {
+			port = conf.QBitTorrent.Port
+		}
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/internal/version", port)
+
+	client := &http.Client{
+		Timeout: *timeout,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check failed with status: %d", resp.StatusCode)
+	}
+
+	fmt.Println("Health check passed")
+	return nil
+}

--- a/pkg/cli/commands/serve.go
+++ b/pkg/cli/commands/serve.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/sirrobot01/debrid-blackhole/cmd"
+	"github.com/sirrobot01/debrid-blackhole/common"
+	"github.com/sirrobot01/debrid-blackhole/pkg/cli"
+)
+
+func init() {
+    cli.Register(cli.Command{
+        Name:        "serve",
+        Description: "Start the Blackhole server",
+        Execute:     executeServe,
+    })
+}
+
+func executeServe(args []string) error {
+    fs := flag.NewFlagSet("serve", flag.ExitOnError)
+    configFile := fs.String("config", "config.json", "path to config file")
+
+    if err := fs.Parse(args); err != nil {
+        return err
+    }
+
+    conf, err := common.LoadConfig(*configFile)
+    if err != nil {
+        return fmt.Errorf("failed to load config: %w", err)
+    }
+
+    common.CONFIG = conf
+    return cmd.Start(context.Background(), conf)
+}

--- a/pkg/cli/commands/version.go
+++ b/pkg/cli/commands/version.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirrobot01/debrid-blackhole/pkg/cli"
+	"github.com/sirrobot01/debrid-blackhole/pkg/version"
+)
+
+func init() {
+    cli.Register(cli.Command{
+        Name:        "version",
+        Description: "Print version information",
+        Execute:     executeVersion,
+    })
+}
+
+func executeVersion(args []string) error {
+    info := version.GetInfo()
+    jsonOutput, err := json.MarshalIndent(info, "", "  ")
+    if err != nil {
+        return fmt.Errorf("failed to marshal version info: %w", err)
+    }
+    fmt.Println(string(jsonOutput))
+    return nil
+}

--- a/pkg/cli/structs.go
+++ b/pkg/cli/structs.go
@@ -1,0 +1,7 @@
+package cli
+
+type Command struct {
+	Name        string
+	Description string
+	Execute     func([]string) error
+}


### PR DESCRIPTION
* Add core cli structure with command registration system
* Implement three main cli commands:
  - `serve`: starts the blackhole server with config file support
  - `health`: checks if the server passed the health check 
  - `version`: displays app version and channel info
* Add command documentation and help text
* Ensure compatibility with distroless container execution
* Update Dockerfile health check to use new health command

The cli can now be accessed in container via:
`docker exec blackhole /blackhole <command>`

To get more details about a command, run:
`docker exec blackhole /blackhole <command> --help`

Example usage:
- `/blackhole serve --config /app/config.json`
- `/blackhole health`
- `/blackhole version`
- `/blackhole health --help`

