### PR TITLE
Keep track of magnet link handler state

### DIFF
--- a/pkg/qbit/server/templates/config.html
+++ b/pkg/qbit/server/templates/config.html
@@ -26,7 +26,7 @@
                                 <label>
                                     <!-- Empty label to keep the button aligned -->
                                 </label>
-                                <div class="btn btn-primary w-100" onclick="registerMagnetLinkHandler()">
+                                <div class="btn btn-primary w-100" onclick="registerMagnetLinkHandler()" id="registerMagnetLink">
                                     Open Magnet Links in DecyphArr
                                 </div>
                             </div>
@@ -326,11 +326,20 @@
                         `${window.location.origin}/download?magnet=%s`,
                         'DecyphArr'
                     );
+                    localStorage.setItem('magnetHandler', 'true');
+                    document.getElementById('registerMagnetLink').innerText = '✅ DecyphArr Can Open Magnet Links';
+                    document.getElementById('registerMagnetLink').classList.add('bg-white', 'text-black');
                     console.log('Registered magnet link handler successfully.');
                 } catch (error) {
                     console.error('Failed to register magnet link handler:', error);
                 }
             }
+        }
+
+        var magnetHandler = localStorage.getItem('magnetHandler');
+        if (magnetHandler === 'true') {
+            document.getElementById('registerMagnetLink').innerText = '✅ DecyphArr Can Open Magnet Links';
+            document.getElementById('registerMagnetLink').classList.add('bg-white', 'text-black');
         }
     </script>
 {{ end }}


### PR DESCRIPTION
This PR is a follow up to #15. The magnet link handler registration will now remember if a user previously registered by storing the state in localStorage.

**Before Registration**:

![image](https://github.com/user-attachments/assets/876c4004-5c48-458e-ae82-40ae045a6521)

**After Registration**:

![image](https://github.com/user-attachments/assets/d7a6043c-7e10-4bb7-ae62-152c5eb05139)
