### PR TITLE
Don't immediately download torrents with the magnet link handler

### DIFF
--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -90,17 +90,12 @@
                 }
             });
 
-            // Read the URL parameters for a magnet link and add it to the download queue if found
+            // Read the URL parameters for a magnet link and add it to the download textarea if found
             const urlParams = new URLSearchParams(window.location.search);
             const magnetURI = urlParams.get('magnet');
             if (magnetURI) {
                 document.getElementById('magnetURI').value = magnetURI;
-                try {
-                    document.getElementById('submitDownload').click();
-                    history.replaceState({}, document.title, window.location.pathname);
-                } catch (error) {
-                    console.error('Error adding download:', error);
-                }
+                history.replaceState({}, document.title, window.location.pathname);
             }
         });
     </script>


### PR DESCRIPTION
PR #15 introduced the magnet link handler. It allowed opening magnet links directly in Decypharr. However, instead of allowing the user to set which options they'd like for the magnet link to downlaod with, the downloads would start automatically.

This (1) doesn't allow for users to set their own download settings and (2) could be a security issue if a malicious magnet link is downloaded.

This PR modifies the magnet link handler's behavior to not immediately start a download and instead just paste the magnet link into the torrent links textarea. This behavior was inspired by qBittorrent.