### PR TITLE
Remember the last used download options

### DIFF
--- a/pkg/qbit/server/templates/download.html
+++ b/pkg/qbit/server/templates/download.html
@@ -35,6 +35,22 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
+            const loadSavedDownloadOptions = () => {
+                const savedCategory = localStorage.getItem('downloadCategory');
+                const savedSymlink = localStorage.getItem('downloadSymlink');
+                document.getElementById('category').value = savedCategory || '';
+                document.getElementById('isSymlink').checked = savedSymlink === 'true'
+            };
+
+            const saveCurrentDownloadOptions = () => {
+                const category = document.getElementById('category').value;
+                const isSymlink = document.getElementById('isSymlink').checked;
+                localStorage.setItem('downloadCategory', category);
+                localStorage.setItem('downloadSymlink', isSymlink.toString());
+            };
+
+            // Load the last used download options from local storage
+            loadSavedDownloadOptions();
 
             // Handle form submission
             document.getElementById('downloadForm').addEventListener('submit', async (e) => {
@@ -89,6 +105,10 @@
                     submitBtn.innerHTML = originalText;
                 }
             });
+
+            // Save the download options to local storage when they change
+            document.getElementById('category').addEventListener('change', saveCurrentDownloadOptions);
+            document.getElementById('isSymlink').addEventListener('change', saveCurrentDownloadOptions);
 
             // Read the URL parameters for a magnet link and add it to the download queue if found
             const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
This PR makes it so that download options are 'remembered'/saved. Whatever a user puts in for the category and symlink options is saved and automatically loaded the next time they visit the page.

This is useful for users that typically only use the webui to download to one category for example.

**Closes**:

- #19 