### PR TITLE
Consistent WebDav file sorting

### DIFF
--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -2,6 +2,10 @@ package web
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/goccy/go-json"
 	"github.com/sirrobot01/decypharr/internal/config"
@@ -11,9 +15,6 @@ import (
 	"github.com/sirrobot01/decypharr/pkg/qbit"
 	"github.com/sirrobot01/decypharr/pkg/service"
 	"github.com/sirrobot01/decypharr/pkg/version"
-	"net/http"
-	"strings"
-	"time"
 )
 
 func (ui *Handler) handleGetArrs(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +143,7 @@ func (ui *Handler) handleGetVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func (ui *Handler) handleGetTorrents(w http.ResponseWriter, r *http.Request) {
-	request.JSONResponse(w, ui.qbit.Storage.GetAll("", "", nil), http.StatusOK)
+	request.JSONResponse(w, ui.qbit.Storage.GetAllSorted("", "", nil, "added_on", false), http.StatusOK)
 }
 
 func (ui *Handler) handleDeleteTorrent(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webdav/handler.go
+++ b/pkg/webdav/handler.go
@@ -221,7 +221,17 @@ func (h *Handler) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 func (h *Handler) getFileInfos(torrent *types.Torrent) []os.FileInfo {
 	files := make([]os.FileInfo, 0, len(torrent.Files))
 	now := time.Now()
+
+	// Sort by file name since the order is lost when using the map
+	sortedFiles := make([]*types.File, 0, len(torrent.Files))
 	for _, file := range torrent.Files {
+		sortedFiles = append(sortedFiles, &file)
+	}
+	slices.SortFunc(sortedFiles, func(a, b *types.File) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	for _, file := range sortedFiles {
 		files = append(files, &FileInfo{
 			name:    file.Name,
 			size:    file.Size,


### PR DESCRIPTION
Because the Debrid files data structure is a map, they lose their order and end up being randomly sorted every time the WebDav page is refreshed.

This PR sorts the files by name in the WebDav `getFileInfos` handler.

**Before:**

https://github.com/user-attachments/assets/0a817288-1db5-4bbb-aeb3-594cb4c5ca7b

**After:**

![Screenshot 2025-05-01 at 21-06-08 Index of _webdav_realdebrid___all___Silicon Valley S01 1080p BluRay REMUX AVC DTS-HD MA 5 1-EPSiLON](https://github.com/user-attachments/assets/71c477b5-9683-41f7-bf29-7f0a8f78ae5c)

