### PR TITLE
fix: AllDebrid webdav compatibility, and uncached downloads

### DIFF
--- a/pkg/debrid/providers/alldebrid/alldebrid.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid.go
@@ -309,7 +309,7 @@ func (ad *AllDebrid) GetFileDownloadLinks(t *types.Torrent) error {
 				errCh <- err
 				return
 			}
-			if link != nil {
+			if link == nil {
 				errCh <- fmt.Errorf("download link is empty")
 				return
 			}

--- a/pkg/store/torrent.go
+++ b/pkg/store/torrent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirrobot01/decypharr/internal/utils"
 	debridTypes "github.com/sirrobot01/decypharr/pkg/debrid"
 	"github.com/sirrobot01/decypharr/pkg/debrid/types"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -207,6 +208,9 @@ func (s *Store) partialTorrentUpdate(t *Torrent, debridTorrent *types.Torrent) *
 	}
 	totalSize := debridTorrent.Bytes
 	progress := (cmp.Or(debridTorrent.Progress, 0.0)) / 100.0
+	if math.IsNaN(progress) || math.IsInf(progress, 0) {
+		progress = 0
+	}
 	sizeCompleted := int64(float64(totalSize) * progress)
 
 	var speed int64


### PR DESCRIPTION
AllDebrid seem to have inconsistent API responses: sometimes magnets is an array, sometimes it's an object/map.
Go's encoding/json cannot unmarshal into a single type when the JSON structure changes.

This causes decypharr to shutdown on startup

Workaround:
* Magnets is a custom type that can unmarshal both arrays and maps.
* The UnmarshalJSON method first tries to decode as an array, then as a map.