### PR TITLE
Fix repair toast always showing Unknown Id

### DIFF
--- a/pkg/web/assets/js/repair.js
+++ b/pkg/web/assets/js/repair.js
@@ -153,10 +153,8 @@ class RepairManager {
                 throw new Error(errorText || 'Failed to start repair');
             }
 
-            const result = await response.json();
-
             window.decypharrUtils.createToast(
-                `Repair job started successfully! Job ID: ${result.job_id?.substring(0, 8) || 'Unknown'}`,
+                'Repair job started successfully!',
                 'success'
             );
 


### PR DESCRIPTION
The `job_id` value is never included in the `/api/repair` response so it always shows "Unknown" in the toast:
<img width="437" height="114" alt="image" src="https://github.com/user-attachments/assets/afa7a47d-44eb-4fec-b294-63e5edda509b" />
