### PR TITLE
Use capitalized `SID` for qbittorrent session cookie to fix decluttarr authentication

### DIFF
--- a/pkg/qbit/context.go
+++ b/pkg/qbit/context.go
@@ -119,11 +119,10 @@ func getUsernameAndPassword(r *http.Request) (string, string, error) {
 	if err == nil && username != "" {
 		return username, password, err
 	}
-	// Try to get from cookie
-	sid, err := r.Cookie("sid")
+	// Try to get from cookie (prefer SID, but keep sid for backward compatibility)
+	sid, err := r.Cookie("SID")
 	if err != nil {
-		// try SID
-		sid, err = r.Cookie("SID")
+		sid, err = r.Cookie("sid")
 	}
 	if err == nil {
 		username, password, err = extractFromSID(sid.Value)

--- a/pkg/qbit/http.go
+++ b/pkg/qbit/http.go
@@ -22,7 +22,7 @@ func (q *QBit) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	if cfg.UseAuth {
 		cookie := &http.Cookie{
-			Name:     "sid",
+			Name:     "SID",
 			Value:    createSID(a.Host, a.Token),
 			Path:     "/",
 			SameSite: http.SameSiteNoneMode,


### PR DESCRIPTION
Decluttarr expects the qBittorrent login cookie to be named `SID` (`response.cookies["SID"]` in `decluttarr/src/settings/_download_clients_qbit.py` [link](https://github.com/ManiMatter/decluttarr/blob/d3ed0f9ed220d887fb19f4740bda69a7a136bbaa/src/settings/_download_clients_qbit.py#L105)).

The current login endpoint was issuing lowercase `sid`, which breaks that compatibility path.

* Set `/api/v2/auth/login` to emit cookie name `SID`
* Keep backward compatibility by still accepting legacy `sid` when reading cookies

Note: the qbittorrent [API docs mentions](https://github.com/ManiMatter/decluttarr/blob/d3ed0f9ed220d887fb19f4740bda69a7a136bbaa/src/settings/_download_clients_qbit.py#L105) of the `SID` cookie are all uppercase, so it looks like this is a good compatibility improvement in general