### PR TITLE
Add handling for RD 'bytes_limit_reached' error

### DIFF
--- a/pkg/manager/link/errors.go
+++ b/pkg/manager/link/errors.go
@@ -133,6 +133,8 @@ func ErrorCodeToLinkError(code string) *Error {
 		return NewPermanentError(ErrLinkNotFound, code)
 	case "bandwidth_exceeded":
 		return NewAccountError(ErrBandwidthExceeded, code)
+	case "bytes_limit_reached":
+		return NewAccountError(ErrBandwidthExceeded, code)
 	case "link_expired":
 		return NewRefetchableError(ErrLinkExpired, code)
 	case "file_not_available":

--- a/pkg/manager/link/errors.go
+++ b/pkg/manager/link/errors.go
@@ -147,6 +147,8 @@ func ErrorCodeToLinkError(code string) *Error {
 		return NewPermanentError(Err404, code)
 	case "429":
 		return NewRetryableError(Err429, code)
+	case "too_many_attempts":
+    	return NewRetryableError(Err429, code)
 	case "503":
 		return NewRetryableError(Err503, code)
 	default:


### PR DESCRIPTION
Real-Debrid can return `bytes_limit_reached` when an account's traffic quota is exhausted.

Currently this error is treated as an unknown error code, which prevents Decypharr from classifying it as an account issue and switching to the next configured account.

This patch maps "bytes_limit_reached" to CategoryAccountIssue so the exhausted account is disabled and failover to alternate accounts can occur.