### PR TITLE
fix(torbox): fix download link URL construction (/ vs ?)

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -455,7 +455,7 @@ func (tb *Torbox) fetchDownloadLink(account *account.Account, id string, file *t
 	query.Set("file_id", file.Id)
 	query.Set("redirect", "true")
 
-	downloadURL := fmt.Sprintf("%s/api/torrents/requestdl/%s", tb.Host, query.Encode())
+	downloadURL := fmt.Sprintf("%s/api/torrents/requestdl?%s", tb.Host, query.Encode())
 
 	now := time.Now()
 


### PR DESCRIPTION
## Bug

When using the DFS backend with TorBox, every file read fails with `[Errno 5] Input/output error`. Debug logs show:

```
failed to get download link: 404: HTTP 404 Not Found
```

## Root Cause

In `fetchDownloadLink`, query parameters are appended as a **path segment** instead of a proper **query string**:

```go
// Before (broken) — query params as path segment
downloadURL := fmt.Sprintf("%s/api/torrents/requestdl/%s", tb.Host, query.Encode())
// Generates: https://api.torbox.app/v1/api/torrents/requestdl/token=xxx&torrent_id=yyy&file_id=zzz
// TorBox has no route matching this → 404
```

## Fix

```go
// After — correct query string
downloadURL := fmt.Sprintf("%s/api/torrents/requestdl?%s", tb.Host, query.Encode())
// Generates: https://api.torbox.app/v1/api/torrents/requestdl?token=xxx&torrent_id=yyy&file_id=zzz
```

**One character change: `/` → `?`**

## File

`pkg/debrid/providers/torbox/torbox.go`, line 458

## Testing

Tested on TorBox with the `hanwen` DFS backend — files are fully readable and stream correctly after this fix.