### PR TITLE
fix: prevent NaN/Inf progress values from breaking the dashboard

### DIFF
--- a/pkg/debrid/providers/alldebrid/alldebrid.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid.go
@@ -264,7 +264,9 @@ func (ad *AllDebrid) GetTorrent(torrentId string) (*types.Torrent, error) {
 		files := ad.flattenFiles(t.Id, data.Files, "", &index)
 		t.Files = files
 	} else {
-		t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
+		if data.Size > 0 {
+			t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
+		}
 		t.Speed = data.DownloadSpeed
 	}
 	return t, nil
@@ -302,7 +304,9 @@ func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
 		files := ad.flattenFiles(t.Id, data.Files, "", &index)
 		t.Files = files
 	} else {
-		t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
+		if data.Size > 0 {
+			t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
+		}
 		t.Speed = data.DownloadSpeed
 	}
 	return nil

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -318,6 +318,9 @@ func (s *Server) handleGetTorrents(w http.ResponseWriter, r *http.Request) {
 
 	// GetReader all torrents
 	allTorrents := s.manager.Queue().ListFilter("", config.ProtocolAll, "", nil, "added_on", false)
+	for _, t := range allTorrents {
+		t.Sanitize()
+	}
 
 	// Apply filters
 	filteredTorrents := make([]*storage.Entry, 0)

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"math"
 	"path"
 	"path/filepath"
 	"time"
@@ -112,6 +113,20 @@ func (e *Entry) Validate() error {
 		return fmt.Errorf("no files in active providerEntry")
 	}
 	return nil
+}
+
+// Sanitize replaces any non-finite float64 values with 0 so the entry can be
+// safely JSON-encoded. This guards against NaN/Inf produced by division-by-zero
+// when a debrid provider reports size=0 for an in-progress torrent.
+func (e *Entry) Sanitize() {
+	if math.IsNaN(e.Progress) || math.IsInf(e.Progress, 0) {
+		e.Progress = 0
+	}
+	for _, p := range e.Providers {
+		if math.IsNaN(p.Progress) || math.IsInf(p.Progress, 0) {
+			p.Progress = 0
+		}
+	}
 }
 
 // CanBeFixed checks if the entry can be repaired


### PR DESCRIPTION
## Summary

- **`alldebrid.go`**: Guard against division by zero when AllDebrid reports `size: 0` for an in-progress torrent. `float64(downloaded) / float64(0) * 100` produces `NaN`/`Inf`, which Go's JSON encoder cannot serialize.
- **`storage/types.go`**: Add `Entry.Sanitize()` method that clamps `NaN`/`Inf` to `0` on both `Entry.Progress` and each `ProviderEntry.Progress`.
- **`server/api.go`**: Call `Sanitize()` on all entries in `handleGetTorrents` so existing bad entries already persisted in `queue.db` are fixed without requiring a DB wipe.

[This closes this issue](https://github.com/sirrobot01/decypharr/issues/219)

## Root Cause

`json.Encoder.Encode()` returns an error for `NaN`/`Inf` float64 values, but the error was discarded (`_ = encoder.Encode(data)`). The HTTP headers were already sent at that point, leaving the body empty. The dashboard UI then fails with:

```
Error loading items: Failed to execute 'json' on 'Response': Unexpected end of JSON input
```

The issue is reproducible by calling `/api/torrents?page=1&limit=20` (fails) vs `/api/torrents?page=1&limit=1` (works — returns only the valid entry).

## Test plan

- Submit an uncached torrent to AllDebrid while `download_uncached: true`
- Verify `GET /api/torrents` returns valid JSON throughout the download lifecycle, including when AllDebrid has not yet reported the total size
- Verify the dashboard loads correctly even if `queue.db` contains entries with previously persisted `NaN`/`Inf` progress values