### PR TITLE
feat(alldebrid): upload .torrent file instead of magnet

### DIFF
--- a/pkg/debrid/providers/alldebrid/alldebrid.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid.go
@@ -1,9 +1,11 @@
 package alldebrid
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -152,7 +154,76 @@ func (ad *AllDebrid) IsAvailable(hashes []string) map[string]bool {
 	return result
 }
 
+func (ad *AllDebrid) doPostFile(endpoint string, fileData []byte, result interface{}) (*http.Response, error) {
+	u, err := url.Parse(ad.Host + endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("files[]", "torrent.torrent")
+	if err != nil {
+		return nil, err
+	}
+	if _, err = part.Write(fileData); err != nil {
+		return nil, err
+	}
+	writer.Close()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), &body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := ad.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if result != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if err := json.ConfigDefault.NewDecoder(resp.Body).Decode(result); err != nil {
+			return resp, err
+		}
+	}
+	return resp, nil
+}
+
 func (ad *AllDebrid) SubmitMagnet(torrent *types.Torrent) (*types.Torrent, error) {
+	if torrent.Magnet.IsTorrent() {
+		return ad.addTorrentFile(torrent)
+	}
+	return ad.addMagnetLink(torrent)
+}
+
+func (ad *AllDebrid) addTorrentFile(torrent *types.Torrent) (*types.Torrent, error) {
+	var data UploadFileResponse
+
+	resp, err := ad.doPostFile("/magnet/upload/file", torrent.Magnet.File, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
+	}
+
+	files := data.Data.Files
+	if len(files) == 0 {
+		return nil, fmt.Errorf("error adding torrent file: no files returned")
+	}
+	f := files[0]
+	if f.Error != nil {
+		return nil, fmt.Errorf("alldebrid file upload error: %s", f.Error.Message)
+	}
+	torrent.Id = strconv.Itoa(f.ID)
+	torrent.Added = time.Now()
+	return torrent, nil
+}
+
+func (ad *AllDebrid) addMagnetLink(torrent *types.Torrent) (*types.Torrent, error) {
 	var data UploadMagnetResponse
 
 	resp, err := ad.doRequest("/magnet/upload", map[string]string{"magnets[]": torrent.Magnet.Link}, &data)
@@ -169,10 +240,8 @@ func (ad *AllDebrid) SubmitMagnet(torrent *types.Torrent) (*types.Torrent, error
 		return nil, fmt.Errorf("error adding torrent. No magnets returned")
 	}
 	magnet := magnets[0]
-	torrentId := strconv.Itoa(magnet.ID)
-	torrent.Id = torrentId
+	torrent.Id = strconv.Itoa(magnet.ID)
 	torrent.Added = time.Now()
-
 	return torrent, nil
 }
 

--- a/pkg/debrid/providers/alldebrid/types.go
+++ b/pkg/debrid/providers/alldebrid/types.go
@@ -71,6 +71,22 @@ type UploadMagnetResponse struct {
 	Error *errorResponse `json:"error"`
 }
 
+type UploadFileResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		Files []struct {
+			File  string         `json:"file"`
+			Name  string         `json:"name"`
+			Hash  string         `json:"hash"`
+			ID    int            `json:"id"`
+			Size  int64          `json:"size"`
+			Ready bool           `json:"ready"`
+			Error *errorResponse `json:"error"`
+		} `json:"files"`
+	} `json:"data"`
+	Error *errorResponse `json:"error"`
+}
+
 type DownloadLink struct {
 	Status string `json:"status"`
 	Data   struct {


### PR DESCRIPTION
## Problem

  When Radarr/Sonarr sends a `.torrent` file to Decypharr, the file was parsed
  locally to extract the magnet link, then **only the magnet string** was sent to
  AllDebrid via `GET /magnet/upload?magnets[]=...`.

  This causes stalls at 0% for torrents from private French trackers (e.g. Torr9,
  C411) that may potentially block magnet resolution by AllDebrid on the BitTorrent network.
  AllDebrid receives the hash but cannot fetch the metadata, so the torrent never
  starts downloading.

  ## Root Cause

  `SubmitMagnet()` always called `/magnet/upload` with the magnet string,
  ignoring `Magnet.File` (the original `.torrent` binary that was already parsed
  and stored in memory).

  RealDebrid already had the correct behavior: it checks `IsTorrent()` and sends
  the binary file when available. AllDebrid had no equivalent path.

  ## Solution

  Added file upload support for AllDebrid using the official
  `POST /magnet/upload/file` endpoint (multipart/form-data).

  When Decypharr receives a `.torrent` file (e.g. from Radarr/Sonarr),
  it now sends the binary directly to AllDebrid instead of resolving the magnet.
  AllDebrid reads the metadata from the file itself — no DHT/tracker resolution
  needed.

  Magnet links (sent without a file) fall back to the existing behavior.

  ## Changes

  - `pkg/debrid/providers/alldebrid/alldebrid.go`
    - Added `doPostFile()`: multipart POST helper
    - Split `SubmitMagnet()` into `addTorrentFile()` (file upload) and
      `addMagnetLink()` (existing magnet behavior)
    - `SubmitMagnet()` now checks `IsTorrent()` to pick the right path

  - `pkg/debrid/providers/alldebrid/types.go`
    - Added `UploadFileResponse` struct matching the `/magnet/upload/file`
      response schema

  ## Behavior

  | Source | Before | After |
  |---|---|---|
  | `.torrent` file from Radarr/Sonarr | Sends magnet string | Sends `.torrent` binary via multipart |
  | Magnet link | Sends magnet string | Sends magnet string (unchanged) |
                                                                                                           