### PR TITLE
Fix/arr sync config overwrite

### DIFF
--- a/pkg/arr/arr.go
+++ b/pkg/arr/arr.go
@@ -271,17 +271,12 @@ func (s *Storage) SyncFromConfig(arrs []config.Arr) {
 	// AddOrUpdate or update arrs from config
 	s.arrs.Range(func(name string, arr *Arr) bool {
 		if ac, ok := newMaps.Load(name); ok {
-			// Update existing arr
-			// is the host URL valid?
+			// Update existing arr with new config values.
+			// Only preserve the resolved host from memory if the new host is invalid.
 			if utils.ValidateURL(ac.Host) == nil {
 				ac.Host = arr.Host
 			}
 			ac.Token = cmp.Or(ac.Token, arr.Token)
-			ac.Cleanup = arr.Cleanup
-			ac.SkipRepair = arr.SkipRepair
-			ac.DownloadUncached = arr.DownloadUncached
-			ac.SelectedDebrid = arr.SelectedDebrid
-			ac.Source = arr.Source
 			newMaps.Store(name, ac)
 		} else {
 			newMaps.Store(name, arr)


### PR DESCRIPTION
## Problem                                                                                                                         
                                                                                                                                     
  After saving Arr settings in the UI (e.g. toggling `download_uncached` or                                                          
  changing the `selected_debrid` provider), the change appeared to save correctly
  and Decypharr restarted — but the UI and API still returned the **previous                                                         
  values**. The only workaround was a full Docker restart.                                                                           
                                                                                                                                     
  ## Root Cause                                                                                                                      
                                                                                                                                     
  `SyncFromConfig` in `pkg/arr/arr.go` is called after a config save to update                                                       
  the in-memory arr storage with the new values. The function correctly creates                                                      
  new `Arr` objects (`ac`) from the incoming config — with the updated values.                                                       
                                                                                                                                     
  However, it then immediately **overwrote** those new values with the old                                                           
  in-memory arr's values:                                                                                                            
                                                                                                                                     
  ```go                                                     
  // ac = new arr built from saved config (correct values)
  // arr = old in-memory arr (stale values)                                                                                          
                                                                                                                                     
  ac.Cleanup = arr.Cleanup                   // ← old overwrites new                                                                 
  ac.SkipRepair = arr.SkipRepair             // ← old overwrites new                                                                 
  ac.DownloadUncached = arr.DownloadUncached // ← old overwrites new                                                                 
  ac.SelectedDebrid = arr.SelectedDebrid     // ← old overwrites new                                                                 
  ac.Source = arr.Source                     // ← old overwrites new
  ```                                                                                                                                                                                               
  The in-memory arr storage was therefore never actually updated. On the next                                                        
  GET /api/config, SyncToConfig read those stale values back and returned
  them to the UI.                                                                                                                    
                                                            
  A full Docker restart bypassed the bug because the arr storage starts empty —                                                      
  the Range over old arrs is a no-op, so the new config values are used as-is.
                                                                                                                                     
  ##  Fix                                                       
                                                                                                                                     
  Removed the lines that overwrote config fields with old in-memory values.

  For existing arrs, the new config values are now kept as-is. Only two                                                              
  legitimate preservation behaviours remain:
                                                                                                                                     
  - Host: if the new host URL fails validation, keep the previously resolved                                                         
  host from memory (handles auto-detected / runtime-resolved URLs)
  - Token: cmp.Or keeps the new token if set, falls back to the old one                                                              
                                                                                                                                     
  ##  Result                                                                                                                             
                                                                                                                                     
  Saving any Arr setting (checkbox or dropdown) now takes effect immediately                                                         
  after the in-app restart, without requiring a Docker restart.
