### PR TITLE
fix(qbit): return 200 on delete of unknown torrent hash

### DIFF
--- a/pkg/server/qbit/http.go
+++ b/pkg/server/qbit/http.go
@@ -174,7 +174,7 @@ func (q *QBit) handleTorrentsDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, hash := range hashes {
 		err := q.manager.Queue().Delete(hash, nil)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "not found") {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
## Problem

  When Sonarr/Radarr tries to remove a torrent from Decypharr after it has
  already been processed (downloaded, symlinked, and cleared from the queue),
  Decypharr returns a **500 Internal Server Error**:

  HTTP request failed: [500:InternalServerError] [POST] at
  [http://decypharr:8282/api/v2/torrents/delete]
  key 9f60304b82f4784774542cec2d62f2d5de61b05c not found

  Sonarr interprets this 500 as a download client connection failure, which
  triggers an unnecessary blacklist of the release and causes it to grab an
  alternative version.

  ## Root Cause

  `handleTorrentsDelete` propagated the "key not found" storage error directly
  as a 500 response. Once Decypharr finishes processing a torrent (symlinks
  created, entry cleaned up), the hash is no longer in the queue. When Sonarr
  later sends a DELETE for that hash, the entry is already gone.

  ## Fix

  A delete of an already-absent key is a success by definition — the end state
  (torrent not in queue) is identical. The handler now ignores "not found"
  errors and returns 200, matching the expected idempotent behavior of the
  qBittorrent API.

  ## Result

  Sonarr/Radarr delete calls no longer cause 500 errors after a completed
  download, preventing false blacklists and unnecessary re-grabs.