### PR TITLE
implement CheckFile for torbox provider

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -13,12 +13,14 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	json "github.com/bytedance/sonic"
 
 	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/customerror"
 	"github.com/sirrobot01/decypharr/internal/logger"
 	"github.com/sirrobot01/decypharr/internal/request"
 	"github.com/sirrobot01/decypharr/internal/utils"
@@ -43,6 +45,9 @@ type Torbox struct {
 	logger                zerolog.Logger
 	Profile               *types.Profile
 	config                config.Debrid
+	downloadPresentCache  sync.Map
+	downloadPresentMu     sync.Mutex
+	downloadPresentLoaded bool
 }
 
 func New(dc config.Debrid, ratelimits map[string]ratelimit.Limiter) (*Torbox, error) {
@@ -340,6 +345,31 @@ func (tb *Torbox) GetTorrent(torrentId string) (*types.Torrent, error) {
 	return t, nil
 }
 
+func (tb *Torbox) loadDownloadPresent() error {
+	offset := 0
+	total := 0
+	for {
+		var res TorrentsListResponse
+		resp, err := tb.doGet("/api/torrents/mylist", map[string]string{"offset": fmt.Sprintf("%d", offset)}, &res)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("torbox API error: Status: %d", resp.StatusCode)
+		}
+		if res.Data == nil || len(*res.Data) == 0 {
+			break
+		}
+		for _, t := range *res.Data {
+			tb.downloadPresentCache.Store(strconv.Itoa(t.Id), t.DownloadPresent)
+		}
+		total += len(*res.Data)
+		offset += len(*res.Data)
+	}
+	tb.logger.Info().Int("count", total).Msg("loaded download_present cache for repair")
+	return nil
+}
+
 func (tb *Torbox) UpdateTorrent(t *types.Torrent) error {
 	var res InfoResponse
 
@@ -571,7 +601,31 @@ func (tb *Torbox) RefreshDownloadLinks() error {
 }
 
 func (tb *Torbox) CheckFile(ctx context.Context, infohash, link string) error {
-	return nil
+	tb.downloadPresentMu.Lock()
+	if !tb.downloadPresentLoaded {
+		if err := tb.loadDownloadPresent(); err != nil {
+			tb.downloadPresentMu.Unlock()
+			return err
+		}
+		tb.downloadPresentLoaded = true
+	}
+	tb.downloadPresentMu.Unlock()
+
+	torrentID := link
+	if strings.HasPrefix(link, "torbox://") {
+		parts := strings.SplitN(strings.TrimPrefix(link, "torbox://"), "/", 2)
+		if len(parts) > 0 {
+			torrentID = parts[0]
+		}
+	}
+
+	if present, ok := tb.downloadPresentCache.Load(torrentID); ok {
+		if !present.(bool) {
+			return customerror.HosterUnavailableError
+		}
+		return nil
+	}
+	return customerror.HosterUnavailableError
 }
 
 func (tb *Torbox) GetAvailableSlots() (int, error) {
@@ -721,5 +775,5 @@ func (tb *Torbox) SpeedTest(ctx context.Context) types.SpeedTestResult {
 
 
 func (tb *Torbox) SupportsCheck() bool {
-	return false
+	return true
 }


### PR DESCRIPTION
TorBox's CheckFile currently returns nil and SupportsCheck returns false,
so the repair worker can never detect expired content on TorBox. When
download_present goes false on a torrent, the symlinks stay around and
playback fails with 404.

This implements CheckFile by loading download_present status from
/api/torrents/mylist into a sync.Map on first call. Paginates through
results the same way GetTorrents does. Returns HosterUnavailableError
when download_present is false, which triggers the existing arr_reacquire
repair flow.

The cache uses a mutex instead of sync.Once so transient API failures
don't permanently disable checking.

Tested with ~1000 torrents (79 with download_present=false). Repair
correctly detects broken entries and triggers re-search through the arr.

Related: #193, #179