### PR TITLE
fix: Torbox download link url and pool panic prevention 

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -455,7 +455,7 @@ func (tb *Torbox) fetchDownloadLink(account *account.Account, id string, file *t
 	query.Set("file_id", file.Id)
 	query.Set("redirect", "true")
 
-	downloadURL := fmt.Sprintf("%s/api/torrents/requestdl/%s", tb.Host, query.Encode())
+	downloadURL := fmt.Sprintf("%s/api/torrents/requestdl?%s", tb.Host, query.Encode())
 
 	now := time.Now()
 

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -270,7 +270,18 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 		tasks = append(tasks, downloadTask{file: file, link: downloadLink.DownloadLink})
 	}
 
-	p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(d.maxDownloads)
+	// If no valid download links were obtained, return error instead of panic
+	if len(tasks) == 0 {
+		return fmt.Errorf("no valid download links available for %s", entry.Name)
+	}
+
+	// Ensure maxDownloads is at least 1 to avoid pool panic
+	maxGoroutines := d.maxDownloads
+	if maxGoroutines <= 0 {
+		maxGoroutines = 1
+	}
+
+	p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(maxGoroutines)
 	for _, task := range tasks {
 		p.Go(func() error {
 			if err := d.localDownloader(
@@ -323,7 +334,13 @@ func (d *Downloader) processUsenetDownload(entry *storage.Entry) error {
 	// Track per-file progress so we can compute the global total across all files
 	fileProgress := make(map[string]int64)
 
-	p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(d.maxDownloads)
+	// Ensure maxDownloads is at least 1 to avoid pool panic
+	maxGoroutines := d.maxDownloads
+	if maxGoroutines <= 0 {
+		maxGoroutines = 1
+	}
+
+	p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(maxGoroutines)
 	for _, file := range files {
 		p.Go(func() error {
 			destPath := filepath.Join(downloadedFolder, file.Name)


### PR DESCRIPTION

## Summary
This PR includes two critical fixes for the Torbox provider and the downloader pool.
## Changes
1. Fix Torbox download link URL construction
File: pkg/debrid/providers/torbox/torbox.go
Query params were appended as a path segment instead of a query string, causing HTTP 404 on every file read when using the DFS backend with TorBox.
```
downloadURL := fmt.Sprintf("%s/api/torrents/requestdl/%s", tb.Host, query.Encode())
+ downloadURL := fmt.Sprintf("%s/api/torrents/requestdl?%s", tb.Host, query.Encode())

Before: requestdl/<encoded-params> → 404

After: requestdl?<encoded-params> → works
```
2. Prevent panic in downloader pool
File: pkg/manager/downloader.go
Two scenarios caused panics:
1.	Empty tasks slice - When no valid download links are available, the pool would panic instead of returning a proper error.
2.	Invalid maxDownloads - When maxDownloads is set to 0 or negative, the pool.New().WithMaxGoroutines() call panics because it requires at least 1 goroutine.
## Fix:
·	Added validation to return a clear error when no valid download links are available
·	Added guard to ensure maxGoroutines is always at least 1 before creating the pool
·	Applied to both processTorrentDownload() and processUsenetDownload() functions
## Testing
Both fixes have been running in production without issues.

## Commits:
·	555fc43 fix(torbox): fix download link URL construction
·	8906001 fix: prevent panic when no download links or maxDownloads <= 0
