### PR TITLE
fix(qbit): use uppercase SID cookie to match qBittorrent

### DIFF
--- a/pkg/server/qbit/http.go
+++ b/pkg/server/qbit/http.go
@@ -23,7 +23,7 @@ func (q *QBit) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	if cfg.UseAuth {
 		cookie := &http.Cookie{
-			Name:     "sid",
+			Name:     "SID",
 			Value:    createSID(a.Host, a.Token),
 			Path:     "/",
 			SameSite: http.SameSiteNoneMode,


### PR DESCRIPTION
## 📌 Description

- decypharr's qBit mock sets the session cookie as `sid`, but real qBittorrent sends `SID`. Clients that parse `Set-Cookie` looking for `SID=` fail to authenticate. Fixes #218.

---

## Target Branch Check (IMPORTANT)
- [X] I confirm this PR is targeting the correct branch

**Expected target:**
- [X] beta (for features)

---

## Changes Made
<!-- List key changes -->
- One line change in `pkg/server/qbit/http.go` to set `Name: "SID"` on the login cookie. `pkg/server/qbit/context.go` already accepts both cases when reading, so existing sessions keep working.

---

## Testing
<!-- How was this tested? -->
- [X] Tested locally

Steps:
1. `POST /api/v2/auth/login` now returns `Set-Cookie: SID=...`. `go build ./...` clean.

---

## Risks / Notes
<!-- Any side effects, migrations, breaking changes -->
- None, backwards compatible
---

## Checklist
- [X] Code builds successfully
- [X] No console/log errors
- [X] Reviewed my own code
- [X] Target branch is correct