### PR TITLE
Fix transient import failures: skip blocklisting on "unexpected error processing file"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
-ARG VERSION=0.0.0
+ARG VERSION=2.2.1
 ARG CHANNEL=dev
 
 # Copy xx scripts for cross-compilation

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
-ARG VERSION=2.2.2
+ARG VERSION=2.2.3
 ARG CHANNEL=dev
 
 # Copy xx scripts for cross-compilation
@@ -59,7 +59,7 @@ RUN apk add --no-cache curl unzip && \
 # Stage 2: Final image
 FROM alpine:latest
 
-ARG VERSION=2.2.2
+ARG VERSION=2.2.3
 ARG CHANNEL=test
 
 LABEL version="${VERSION}-${CHANNEL}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
-ARG VERSION=2.2.1
+ARG VERSION=2.2.2
 ARG CHANNEL=dev
 
 # Copy xx scripts for cross-compilation
@@ -59,7 +59,7 @@ RUN apk add --no-cache curl unzip && \
 # Stage 2: Final image
 FROM alpine:latest
 
-ARG VERSION=2.2.1
+ARG VERSION=2.2.2
 ARG CHANNEL=test
 
 LABEL version="${VERSION}-${CHANNEL}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ RUN apk add --no-cache curl unzip && \
 # Stage 2: Final image
 FROM alpine:latest
 
-ARG VERSION=0.0.0
-ARG CHANNEL=dev
+ARG VERSION=2.2.1
+ARG CHANNEL=test
 
 LABEL version="${VERSION}-${CHANNEL}"
 LABEL org.opencontainers.image.source="https://github.com/sirrobot01/decypharr"

--- a/pkg/arr/arr.go
+++ b/pkg/arr/arr.go
@@ -64,8 +64,8 @@ type Arr struct {
 	Source           Source `json:"source,omitempty"`          // The source of the arr, e.g. "auto", "manual". Auto means it was automatically detected from the arr
 }
 
-type DownloadClientSchema struct {
-	RemoveFailedDownloads bool `json:"removeFailedDownloads"`
+type DownloadClientConfigSchema struct {
+	AutoRedownloadFailed bool `json:"autoRedownloadFailed"`
 }
 
 func New(name, host, token string, cleanup, skipRepair bool, downloadUncached *bool, selectedDebrid, source string) *Arr {
@@ -152,20 +152,13 @@ func (a *Arr) Validate() error {
 	return nil
 }
 
-func (a *Arr) GetRemoveFailedDownloads() bool {
-	var data []DownloadClientSchema
-	resp, err := a.Request(http.MethodGet, "api/v3/downloadclient", nil, &data)
-	if err != nil || resp.StatusCode != http.StatusOK || len(data) == 0 {
+func (a *Arr) GetAutoRedownloadFailed() bool {
+	var data DownloadClientConfigSchema
+	resp, err := a.Request(http.MethodGet, "api/v3/config/downloadclient", nil, &data)
+	if err != nil || resp.StatusCode != http.StatusOK {
 		return false
 	}
-
-	for _, client := range data {
-		if client.RemoveFailedDownloads {
-			return true
-		}
-	}
-
-	return false
+	return data.AutoRedownloadFailed
 }
 
 type Storage struct {

--- a/pkg/arr/arr.go
+++ b/pkg/arr/arr.go
@@ -64,6 +64,10 @@ type Arr struct {
 	Source           Source `json:"source,omitempty"`          // The source of the arr, e.g. "auto", "manual". Auto means it was automatically detected from the arr
 }
 
+type DownloadClientSchema struct {
+	RemoveFailedDownloads bool `json:"removeFailedDownloads"`
+}
+
 func New(name, host, token string, cleanup, skipRepair bool, downloadUncached *bool, selectedDebrid, source string) *Arr {
 	return &Arr{
 		Name:             name,
@@ -146,6 +150,22 @@ func (a *Arr) Validate() error {
 		return fmt.Errorf("failed to validate arr %s: %s", a.Name, resp.Status)
 	}
 	return nil
+}
+
+func (a *Arr) GetRemoveFailedDownloads() bool {
+	var data []DownloadClientSchema
+	resp, err := a.Request(http.MethodGet, "api/v3/downloadclient", nil, &data)
+	if err != nil || resp.StatusCode != http.StatusOK || len(data) == 0 {
+		return false
+	}
+
+	for _, client := range data {
+		if client.RemoveFailedDownloads {
+			return true
+		}
+	}
+
+	return false
 }
 
 type Storage struct {

--- a/pkg/arr/arr.go
+++ b/pkg/arr/arr.go
@@ -7,6 +7,8 @@ import (
 	json "github.com/bytedance/sonic"
 	"io"
 	"net/http"
+	"net/url"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -317,6 +319,85 @@ func (a *Arr) Refresh() {
 	}
 
 	_, _ = a.Request(http.MethodPost, "api/v3/command", payload, nil)
+}
+
+type filesystemFile struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type filesystemListing struct {
+	Path  string           `json:"path"`
+	Files []filesystemFile `json:"files"`
+}
+
+// CanSeePath checks whether arr can see the provided path via its filesystem endpoint.
+func (a *Arr) CanSeePath(path string, expectedFiles []string) (bool, error) {
+	params := url.Values{}
+	params.Set("path", path)
+	params.Set("includeFiles", "true")
+	params.Set("allowFoldersWithoutTrailingSlashes", "true")
+	endpoint := "api/v3/filesystem?" + params.Encode()
+
+	resp, err := a.Request(http.MethodGet, endpoint, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	if resp.Body == nil {
+		return false, fmt.Errorf("filesystem check failed: empty response body")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return false, fmt.Errorf("filesystem check failed: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("filesystem check failed to read response: %w", err)
+	}
+
+	var listings []filesystemListing
+	if err := json.Unmarshal(body, &listings); err != nil {
+		var single filesystemListing
+		if errSingle := json.Unmarshal(body, &single); errSingle != nil {
+			return false, fmt.Errorf("filesystem check failed to parse response: %w", err)
+		}
+		listings = []filesystemListing{single}
+	}
+
+	if len(listings) == 0 {
+		return false, nil
+	}
+
+	listing := listings[0]
+
+	if len(expectedFiles) == 0 {
+		return len(listing.Files) > 0 || strings.TrimRight(listing.Path, "/") == strings.TrimRight(path, "/"), nil
+	}
+
+	seen := make(map[string]struct{}, len(listing.Files))
+	for _, f := range listing.Files {
+		name := strings.ToLower(strings.TrimSpace(f.Name))
+		if name == "" {
+			name = strings.ToLower(strings.TrimSpace(filepath.Base(f.Path)))
+		}
+		if name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+
+	for _, expected := range expectedFiles {
+		name := strings.ToLower(strings.TrimSpace(filepath.Base(expected)))
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func inferType(host, name string) Type {

--- a/pkg/arr/arr.go
+++ b/pkg/arr/arr.go
@@ -332,7 +332,7 @@ type filesystemListing struct {
 }
 
 // CanSeePath checks whether arr can see the provided path via its filesystem endpoint.
-func (a *Arr) CanSeePath(path string, expectedFiles []string) (bool, error) {
+func (a *Arr) CanSeePath(path string, expectedFiles []string) (bool, []filesystemFile, error) {
 	params := url.Values{}
 	params.Set("path", path)
 	params.Set("includeFiles", "true")
@@ -341,63 +341,79 @@ func (a *Arr) CanSeePath(path string, expectedFiles []string) (bool, error) {
 
 	resp, err := a.Request(http.MethodGet, endpoint, nil, nil)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	if resp.Body == nil {
-		return false, fmt.Errorf("filesystem check failed: empty response body")
+		return false, nil, fmt.Errorf("filesystem check failed: empty response body")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return false, fmt.Errorf("filesystem check failed: %s", resp.Status)
+		return false, nil, fmt.Errorf("filesystem check failed: %s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return false, fmt.Errorf("filesystem check failed to read response: %w", err)
+		return false, nil, fmt.Errorf("filesystem check failed to read response: %w", err)
 	}
 
 	var listings []filesystemListing
 	if err := json.Unmarshal(body, &listings); err != nil {
 		var single filesystemListing
 		if errSingle := json.Unmarshal(body, &single); errSingle != nil {
-			return false, fmt.Errorf("filesystem check failed to parse response: %w", err)
+			return false, nil, fmt.Errorf("filesystem check failed to parse response: %w", err)
 		}
 		listings = []filesystemListing{single}
 	}
 
 	if len(listings) == 0 {
-		return false, nil
+		return false, nil, nil
 	}
 
-	listing := listings[0]
+	allFiles := make([]filesystemFile, 0)
+	for _, listing := range listings {
+		allFiles = append(allFiles, listing.Files...)
+	}
 
 	if len(expectedFiles) == 0 {
-		return len(listing.Files) > 0 || strings.TrimRight(listing.Path, "/") == strings.TrimRight(path, "/"), nil
+		for _, listing := range listings {
+			if len(listing.Files) > 0 || strings.TrimRight(listing.Path, "/") == strings.TrimRight(path, "/") {
+				return true, allFiles, nil
+			}
+		}
+		return false, allFiles, nil
 	}
 
-	seen := make(map[string]struct{}, len(listing.Files))
-	for _, f := range listing.Files {
-		name := strings.ToLower(strings.TrimSpace(f.Name))
-		if name == "" {
-			name = strings.ToLower(strings.TrimSpace(filepath.Base(f.Path)))
-		}
-		if name != "" {
-			seen[name] = struct{}{}
+	seenCounts := make(map[string]int)
+	for _, listing := range listings {
+		for _, f := range listing.Files {
+			name := strings.ToLower(strings.TrimSpace(f.Name))
+			if name == "" {
+				name = strings.ToLower(strings.TrimSpace(filepath.Base(f.Path)))
+			}
+			if name != "" {
+				seenCounts[name]++
+			}
 		}
 	}
+
+	expectedCounts := make(map[string]int)
 
 	for _, expected := range expectedFiles {
 		name := strings.ToLower(strings.TrimSpace(filepath.Base(expected)))
 		if name == "" {
 			continue
 		}
-		if _, ok := seen[name]; !ok {
-			return false, nil
+		expectedCounts[name]++
+	}
+
+	for name, expectedCount := range expectedCounts {
+		if seenCounts[name] < expectedCount {
+			return false, allFiles, nil
 		}
 	}
 
-	return true, nil
+	return true, allFiles, nil
 }
 
 func inferType(host, name string) Type {

--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -123,6 +123,19 @@ func queueFilter(q QueueSchema, autoRedownloadFailed bool) QueueAction {
 		// Check status messages for specific errors
 		messages := q.StatusMessages
 		if len(messages) > 0 {
+			// "Unexpected error processing file" is often transient (race/mount visibility). However "one or more episodes expected.." will catch this and blocklist it.
+			// This will quickly iterate and see if there is a processing error first and leave it for manual adjustment. Most of the time sonarr will be able to import these files on the next pass.
+			// If we use fregapples CanSeePath fuction in arr.go to check if the file is visible to sonarr, we can avoid a lot of these false positives and only blocklist the ones that are truly not visible to sonarr.
+			// Meaning, only a small fraction of the "unexpected error processing file" will be truly unexpected and not just a race condition or mount visibility issue. But this check will allow the user to decide if
+			// it is truly unexpected and blocklist it, or if it is just a transient issue and let sonarr handle it on the next pass.
+			for _, m := range messages {
+				title := strings.ToLower(m.Title)
+				joinedMessages := strings.ToLower(strings.Join(m.Messages, " "))
+				if strings.Contains(title, "unexpected error processing file") || strings.Contains(joinedMessages, "unexpected error processing file") {
+					return QueueActionNone
+				}
+			}
+
 			for _, m := range messages {
 				if strings.Contains(strings.ToLower(strings.Join(m.Messages, " ")), "no files found are eligible") {
 					return QueueActionBlocklist

--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -107,14 +107,14 @@ func (a *Arr) GetQueue() []QueueSchema {
 	return results
 }
 
-func queueFilter(q QueueSchema) QueueAction {
+func queueFilter(q QueueSchema, removeFailedDownloads bool) QueueAction {
 	// Check for failed downloads(for both usenet and torrent)
-	if q.Status == "failed" {
+	if q.Status == "failed" && removeFailedDownloads {
 		return QueueActionBlocklist
 	}
 
 	// Check for completed downloads with warning status and import pending state
-	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" {
+	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && removeFailedDownloads {
 		// Check status messages for specific errors
 		messages := q.StatusMessages
 		if len(messages) > 0 {
@@ -142,10 +142,11 @@ func (a *Arr) CleanupQueue() error {
 		return fmt.Errorf("arr not configured")
 	}
 	queue := a.GetQueue()
+	removeFailedDownloads := a.GetRemoveFailedDownloads()
 	blacklists := make(map[int]bool)
 	manualImports := make(map[string]bool)
 	for _, q := range queue {
-		switch queueFilter(q) {
+		switch queueFilter(q, removeFailedDownloads) {
 		case QueueActionBlocklist:
 			blacklists[q.Id] = true
 		case QueueActionImport:

--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -109,16 +109,17 @@ func (a *Arr) GetQueue() []QueueSchema {
 
 func queueFilter(q QueueSchema, autoRedownloadFailed bool) QueueAction {
 	// Temporary testing override.
-	autoRedownloadFailed = true
+	// autoRedownloadFailed = true
 
 	// Check for failed downloads(for both usenet and torrent)
-	if q.Status == "failed" && autoRedownloadFailed {
-		fmt.Printf("[queueFilter] failed item: %+v\n", q)
+	// if q.Status == "failed" && autoRedownloadFailed {
+	if q.Status == "failed" {
 		return QueueActionBlocklist
 	}
 
 	// Check for completed downloads with warning status and import pending state
-	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && autoRedownloadFailed {
+	// if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && autoRedownloadFailed {
+	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" {
 		fmt.Printf("[queueFilter] completed warning item: %+v\n", q)
 		// Check status messages for specific errors
 		messages := q.StatusMessages

--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -107,14 +107,14 @@ func (a *Arr) GetQueue() []QueueSchema {
 	return results
 }
 
-func queueFilter(q QueueSchema, removeFailedDownloads bool) QueueAction {
+func queueFilter(q QueueSchema, autoRedownloadFailed bool) QueueAction {
 	// Check for failed downloads(for both usenet and torrent)
-	if q.Status == "failed" && removeFailedDownloads {
+	if q.Status == "failed" && autoRedownloadFailed {
 		return QueueActionBlocklist
 	}
 
 	// Check for completed downloads with warning status and import pending state
-	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && removeFailedDownloads {
+	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && autoRedownloadFailed {
 		// Check status messages for specific errors
 		messages := q.StatusMessages
 		if len(messages) > 0 {
@@ -142,11 +142,11 @@ func (a *Arr) CleanupQueue() error {
 		return fmt.Errorf("arr not configured")
 	}
 	queue := a.GetQueue()
-	removeFailedDownloads := a.GetRemoveFailedDownloads()
+	autoRedownloadFailed := a.GetAutoRedownloadFailed()
 	blacklists := make(map[int]bool)
 	manualImports := make(map[string]bool)
 	for _, q := range queue {
-		switch queueFilter(q, removeFailedDownloads) {
+		switch queueFilter(q, autoRedownloadFailed) {
 		case QueueActionBlocklist:
 			blacklists[q.Id] = true
 		case QueueActionImport:

--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -108,13 +108,18 @@ func (a *Arr) GetQueue() []QueueSchema {
 }
 
 func queueFilter(q QueueSchema, autoRedownloadFailed bool) QueueAction {
+	// Temporary testing override.
+	autoRedownloadFailed = true
+
 	// Check for failed downloads(for both usenet and torrent)
 	if q.Status == "failed" && autoRedownloadFailed {
+		fmt.Printf("[queueFilter] failed item: %+v\n", q)
 		return QueueActionBlocklist
 	}
 
 	// Check for completed downloads with warning status and import pending state
 	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && autoRedownloadFailed {
+		fmt.Printf("[queueFilter] completed warning item: %+v\n", q)
 		// Check status messages for specific errors
 		messages := q.StatusMessages
 		if len(messages) > 0 {

--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -108,27 +108,18 @@ func (a *Arr) GetQueue() []QueueSchema {
 }
 
 func queueFilter(q QueueSchema, autoRedownloadFailed bool) QueueAction {
-	// Temporary testing override.
-	// autoRedownloadFailed = true
-
 	// Check for failed downloads(for both usenet and torrent)
-	// if q.Status == "failed" && autoRedownloadFailed {
-	if q.Status == "failed" {
+	if q.Status == "failed" && autoRedownloadFailed {
 		return QueueActionBlocklist
 	}
 
 	// Check for completed downloads with warning status and import pending state
-	// if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && autoRedownloadFailed {
-	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" {
-		fmt.Printf("[queueFilter] completed warning item: %+v\n", q)
+	if q.Status == "completed" && q.TrackedDownloadStatus == "warning" && autoRedownloadFailed {
 		// Check status messages for specific errors
 		messages := q.StatusMessages
 		if len(messages) > 0 {
-			// "Unexpected error processing file" is often transient (race/mount visibility). However "one or more episodes expected.." will catch this and blocklist it.
-			// This will quickly iterate and see if there is a processing error first and leave it for manual adjustment. Most of the time sonarr will be able to import these files on the next pass.
-			// If we use fregapples CanSeePath fuction in arr.go to check if the file is visible to sonarr, we can avoid a lot of these false positives and only blocklist the ones that are truly not visible to sonarr.
-			// Meaning, only a small fraction of the "unexpected error processing file" will be truly unexpected and not just a race condition or mount visibility issue. But this check will allow the user to decide if
-			// it is truly unexpected and blocklist it, or if it is just a transient issue and let sonarr handle it on the next pass.
+			// "Unexpected error processing file" is transient — typically a race condition or mount
+			// visibility issue. Leave these alone so arr can retry on the next pass.
 			for _, m := range messages {
 				title := strings.ToLower(m.Title)
 				joinedMessages := strings.ToLower(strings.Join(m.Messages, " "))

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -132,7 +132,7 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 	go func() {
 		// 20s delay to allow any post-processing to complete before refreshing arr
 		time.Sleep(20 * time.Second)
-		d.manager.Logger().Info().Str("entry", entry.Name).Msg("Triggering arr refresh in 20s after download completion")
+		d.logger.Info().Msgf("Triggering arr refresh in 20s after download completion")
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -118,7 +118,7 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// 20s delay to allow any post-processing to complete before marking as completed
 	d.logger.Info().Msgf("Marking Complete in 20s after download completion")
-	time.Sleep(20 * time.Second)
+	// time.Sleep(20 * time.Second)
 
 	// Mark as completed
 	entry.MarkAsCompleted(entry.DownloadPath())
@@ -220,18 +220,18 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 	_ = d.manager.queue.Update(entry)
 
 	// Run ffprobe on files to warm cache and trigger imports
-	if !d.manager.config.SkipPreCache && len(filePaths) > 0 {
-		probeFiles := filePaths
-		if len(probeFiles) > MaxNZBPreCacheFiles {
-			probeFiles = probeFiles[:MaxNZBPreCacheFiles]
-		}
-		d.logger.Debug().Int("files", len(probeFiles)).Msgf("Running ffprobe on %s", entry.Name)
-		if err := d.manager.RunFFprobe(probeFiles); err != nil {
-			d.logger.Error().Msgf("Failed to run ffprobe: %s", err)
-		} else {
-			d.logger.Debug().Str("entry", entry.Name).Msgf("Ran ffprobe on %d/%d files", len(probeFiles), len(filePaths))
-		}
-	}
+	// if !d.manager.config.SkipPreCache && len(filePaths) > 0 {
+	// 	probeFiles := filePaths
+	// 	if len(probeFiles) > MaxNZBPreCacheFiles {
+	// 		probeFiles = probeFiles[:MaxNZBPreCacheFiles]
+	// 	}
+	// 	d.logger.Debug().Int("files", len(probeFiles)).Msgf("Running ffprobe on %s", entry.Name)
+	// 	if err := d.manager.RunFFprobe(probeFiles); err != nil {
+	// 		d.logger.Error().Msgf("Failed to run ffprobe: %s", err)
+	// 	} else {
+	// 		d.logger.Debug().Str("entry", entry.Name).Msgf("Ran ffprobe on %d/%d files", len(probeFiles), len(filePaths))
+	// 	}
+	// }
 
 	d.markAsCompleted(entry)
 

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -228,24 +228,22 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		}
 	}
 
-	d.markAsCompleted(entry)
-	// go d.completeSymlinkAsync(entry, mountPath)
+	// d.markAsCompleted(entry)
+	go d.completeSymlinkAsync(entry, mountPath)
 
 	return nil
 }
 
 func (d *Downloader) completeSymlinkAsync(entry *storage.Entry, mountPath string) {
-	d.waitForArrFilesystem(entry, mountPath, 2*time.Minute, 2*time.Second)
+	d.waitForArrFilesystem(entry, mountPath, 2*time.Minute, 3*time.Second, 3)
 	d.markAsCompleted(entry)
 }
 
-func (d *Downloader) waitForArrFilesystem(entry *storage.Entry, mountPath string, timeout time.Duration, interval time.Duration) {
+func (d *Downloader) waitForArrFilesystem(entry *storage.Entry, mountPath string, timeout time.Duration, interval time.Duration, stableSuccessesRequired int) {
 	a := d.manager.arr.GetOrCreate(entry.Category)
 	if a == nil || a.Host == "" || a.Token == "" {
 		return
 	}
-
-	const stableSuccessesRequired = 2
 
 	files := entry.GetActiveFiles()
 	expected := make([]string, 0, len(files))

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -130,8 +130,9 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// Trigger arr refresh
 	go func() {
-		// Small delay to allow any post-processing to complete before refreshing arr
+		// 20s delay to allow any post-processing to complete before refreshing arr
 		time.Sleep(20 * time.Second)
+		d.manager.Logger().Info().Str("entry", entry.Name).Msg("Triggering arr refresh in 20s after download completion")
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -118,7 +118,7 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// 20s delay to allow any post-processing to complete before marking as completed
 	d.logger.Info().Msgf("Marking Complete in 20s after download completion")
-	// time.Sleep(20 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	// Mark as completed
 	entry.MarkAsCompleted(entry.DownloadPath())
@@ -220,18 +220,18 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 	_ = d.manager.queue.Update(entry)
 
 	// Run ffprobe on files to warm cache and trigger imports
-	// if !d.manager.config.SkipPreCache && len(filePaths) > 0 {
-	// 	probeFiles := filePaths
-	// 	if len(probeFiles) > MaxNZBPreCacheFiles {
-	// 		probeFiles = probeFiles[:MaxNZBPreCacheFiles]
-	// 	}
-	// 	d.logger.Debug().Int("files", len(probeFiles)).Msgf("Running ffprobe on %s", entry.Name)
-	// 	if err := d.manager.RunFFprobe(probeFiles); err != nil {
-	// 		d.logger.Error().Msgf("Failed to run ffprobe: %s", err)
-	// 	} else {
-	// 		d.logger.Debug().Str("entry", entry.Name).Msgf("Ran ffprobe on %d/%d files", len(probeFiles), len(filePaths))
-	// 	}
-	// }
+	if !d.manager.config.SkipPreCache && len(filePaths) > 0 {
+		probeFiles := filePaths
+		if len(probeFiles) > MaxNZBPreCacheFiles {
+			probeFiles = probeFiles[:MaxNZBPreCacheFiles]
+		}
+		d.logger.Debug().Int("files", len(probeFiles)).Msgf("Running ffprobe on %s", entry.Name)
+		if err := d.manager.RunFFprobe(probeFiles); err != nil {
+			d.logger.Error().Msgf("Failed to run ffprobe: %s", err)
+		} else {
+			d.logger.Debug().Str("entry", entry.Name).Msgf("Ran ffprobe on %d/%d files", len(probeFiles), len(filePaths))
+		}
+	}
 
 	d.markAsCompleted(entry)
 

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -228,7 +228,8 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		}
 	}
 
-	go d.completeSymlinkAsync(entry, mountPath)
+	d.markAsCompleted(entry)
+	// go d.completeSymlinkAsync(entry, mountPath)
 
 	return nil
 }

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -130,8 +130,6 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// Trigger arr refresh
 	go func() {
-		// Small delay to allow any post-processing to complete before refreshing arr
-		time.Sleep(2 * time.Second)
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -130,6 +130,8 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// Trigger arr refresh
 	go func() {
+		// Small delay to allow any post-processing to complete before refreshing arr
+		time.Sleep(2 * time.Second)
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -228,11 +228,14 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		}
 	}
 
-	d.waitForArrFilesystem(entry, mountPath, 2*time.Minute, 2*time.Second)
-
-	d.markAsCompleted(entry)
+	go d.completeSymlinkAsync(entry, mountPath)
 
 	return nil
+}
+
+func (d *Downloader) completeSymlinkAsync(entry *storage.Entry, mountPath string) {
+	d.waitForArrFilesystem(entry, mountPath, 2*time.Minute, 2*time.Second)
+	d.markAsCompleted(entry)
 }
 
 func (d *Downloader) waitForArrFilesystem(entry *storage.Entry, mountPath string, timeout time.Duration, interval time.Duration) {

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -116,9 +116,9 @@ func (d *Downloader) process(entry *storage.Entry, mountPath string) error {
 
 func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
-	// 10s delay to allow any post-processing to complete before marking as completed
+	// 20s delay to allow any post-processing to complete before marking as completed
 	d.logger.Info().Msgf("Marking Complete in 20s after download completion")
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	// Mark as completed
 	entry.MarkAsCompleted(entry.DownloadPath())

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -115,9 +115,11 @@ func (d *Downloader) process(entry *storage.Entry, mountPath string) error {
 }
 
 func (d *Downloader) markAsCompleted(entry *storage.Entry) {
-	// 20s delay to allow any post-processing to complete before marking as completed
-	d.logger.Info().Msgf("Triggering arr refresh in 20s after download completion")
-	time.Sleep(20 * time.Second)
+
+	// 10s delay to allow any post-processing to complete before marking as completed
+	d.logger.Info().Msgf("Marking Complete in 20s after download completion")
+	time.Sleep(10 * time.Second)
+
 	// Mark as completed
 	entry.MarkAsCompleted(entry.DownloadPath())
 	_ = d.manager.queue.Update(entry)

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -244,6 +244,8 @@ func (d *Downloader) waitForArrFilesystem(entry *storage.Entry, mountPath string
 		return
 	}
 
+	const stableSuccessesRequired = 2
+
 	files := entry.GetActiveFiles()
 	expected := make([]string, 0, len(files))
 	for _, file := range files {
@@ -251,15 +253,36 @@ func (d *Downloader) waitForArrFilesystem(entry *storage.Entry, mountPath string
 	}
 
 	deadline := time.Now().Add(timeout)
+	stableSuccesses := 0
 	for attempt := 1; ; attempt++ {
-		visible, err := a.CanSeePath(mountPath, expected)
+		visible, apiFiles, err := a.CanSeePath(mountPath, expected)
+		if err == nil {
+			for _, apiFile := range apiFiles {
+				name := strings.TrimSpace(apiFile.Name)
+				if name == "" {
+					name = filepath.Base(apiFile.Path)
+				}
+				d.logger.Debug().
+					Str("arr", a.Name).
+					Int("attempt", attempt).
+					Str("file", name).
+					Str("file_path", apiFile.Path).
+					Msg("arr filesystem file")
+			}
+		}
 		if err == nil && visible {
-			d.logger.Info().
-				Str("arr", a.Name).
-				Int("attempt", attempt).
-				Str("path", mountPath).
-				Msg("arr filesystem can see download path")
-			return
+			stableSuccesses++
+			if stableSuccesses >= stableSuccessesRequired {
+				d.logger.Info().
+					Str("arr", a.Name).
+					Int("attempt", attempt).
+					Int("expected_files", len(expected)).
+					Str("path", mountPath).
+					Msg("arr filesystem can see all expected files")
+				return
+			}
+		} else {
+			stableSuccesses = 0
 		}
 
 		if err != nil {

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -115,6 +115,9 @@ func (d *Downloader) process(entry *storage.Entry, mountPath string) error {
 }
 
 func (d *Downloader) markAsCompleted(entry *storage.Entry) {
+	// 20s delay to allow any post-processing to complete before marking as completed
+	d.logger.Info().Msgf("Triggering arr refresh in 20s after download completion")
+	time.Sleep(20 * time.Second)
 	// Mark as completed
 	entry.MarkAsCompleted(entry.DownloadPath())
 	_ = d.manager.queue.Update(entry)
@@ -130,9 +133,6 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// Trigger arr refresh
 	go func() {
-		// 20s delay to allow any post-processing to complete before refreshing arr
-		time.Sleep(20 * time.Second)
-		d.logger.Info().Msgf("Triggering arr refresh in 20s after download completion")
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -131,7 +131,7 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 	// Trigger arr refresh
 	go func() {
 		// Small delay to allow any post-processing to complete before refreshing arr
-		time.Sleep(2 * time.Second)
+		time.Sleep(20 * time.Second)
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -115,11 +115,6 @@ func (d *Downloader) process(entry *storage.Entry, mountPath string) error {
 }
 
 func (d *Downloader) markAsCompleted(entry *storage.Entry) {
-
-	// 20s delay to allow any post-processing to complete before marking as completed
-	d.logger.Info().Msgf("Marking Complete in 20s after download completion")
-	time.Sleep(20 * time.Second)
-
 	// Mark as completed
 	entry.MarkAsCompleted(entry.DownloadPath())
 	_ = d.manager.queue.Update(entry)
@@ -233,9 +228,56 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		}
 	}
 
+	d.waitForArrFilesystem(entry, mountPath, 2*time.Minute, 2*time.Second)
+
 	d.markAsCompleted(entry)
 
 	return nil
+}
+
+func (d *Downloader) waitForArrFilesystem(entry *storage.Entry, mountPath string, timeout time.Duration, interval time.Duration) {
+	a := d.manager.arr.GetOrCreate(entry.Category)
+	if a == nil || a.Host == "" || a.Token == "" {
+		return
+	}
+
+	files := entry.GetActiveFiles()
+	expected := make([]string, 0, len(files))
+	for _, file := range files {
+		expected = append(expected, file.Name)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for attempt := 1; ; attempt++ {
+		visible, err := a.CanSeePath(mountPath, expected)
+		if err == nil && visible {
+			d.logger.Info().
+				Str("arr", a.Name).
+				Int("attempt", attempt).
+				Str("path", mountPath).
+				Msg("arr filesystem can see download path")
+			return
+		}
+
+		if err != nil {
+			d.logger.Debug().
+				Err(err).
+				Str("arr", a.Name).
+				Int("attempt", attempt).
+				Msg("arr filesystem check not ready")
+		}
+
+		if time.Now().After(deadline) {
+			d.logger.Warn().
+				Str("arr", a.Name).
+				Str("path", mountPath).
+				Dur("timeout", timeout).
+				Msg("timed out waiting for arr filesystem visibility")
+			return
+		}
+
+		time.Sleep(interval)
+	}
 }
 
 // processDownload downloads all files for an entry with progress tracking

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,6 +9,9 @@ UMASK=${UMASK:-022}
 # Set umask
 umask "$UMASK"
 
+# Test to see if docker is getting new values for env vars
+echo "Test"
+
 # Function to create directories and files
 setup_directories() {
     # Ensure directories exist

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,9 +9,6 @@ UMASK=${UMASK:-022}
 # Set umask
 umask "$UMASK"
 
-# Test to see if docker is getting new values for env vars
-echo "Test"
-
 # Function to create directories and files
 setup_directories() {
     # Ensure directories exist


### PR DESCRIPTION
## 📌 Description

Fixes transient "Unexpected error processing file" warnings causing valid releases to be incorrectly blocklisted. These errors are typically race conditions or mount visibility timing issues where arr can recover on the next import pass. Also adds a filesystem visibility confirmation window before signalling arr to import, reducing the frequency of these transient errors occurring in the first place.

---

## Target Branch Check (IMPORTANT)
- [x] I confirm this PR is targeting the correct branch

**Expected target:**
- [x] beta (for features))

---

## Changes Made
- `pkg/arr/arr.go`: Added `CanSeePath()` — queries arr's filesystem API to verify the download path and all expected files are visible before signalling import
- `pkg/manager/downloader.go`: Added `waitForArrFilesystem()` — polls `CanSeePath` with configurable interval and required consecutive successes before marking a download complete.
-  `pkg/manager/downloader.go`: Removed d.markAsCompleted(entry) and added `go d.completeSymlinkAsync`
- `pkg/manager/downloader.go`:Added `completeSymlinkAsync()` — starts a go routine that calls `waitForArrFileystem()` and then when it completes it then runs `markAsCompleted()`. Async is so it doens't stop other downloads from starting.
- `pkg/arr/history.go`: Added early-return in `queueFilter` to skip blocklisting when any status message contains "unexpected error processing file" — these are left alone so arr can retry on the next pass

---

## Testing
- [x] Tested locally
- [x] Another user following my issue thread had success with my image. 

Steps:
1. Built and deployed image to server with changes
2. Grabbed 6 TV series simultaneously (20+ episodes each)
3. Monitored queue — zero "unexpected error processing file" blocklist events observed (none of the releases even showed a import warning at all, even briefly), compared to frequent occurrences before the change

---

## Risks / Notes
<!-- Any side effects, migrations, breaking changes -->
- The 6s minimum visibility window slightly increases the time (by 6 seconds) before arr is notified for fast imports, but has no impact on slower ones and prevents false blocklists
- Releases with genuine, non-transient import errors are unaffected — only the specific "unexpected error processing file" message is exempted; all other warning conditions (no eligible files, empty download, etc.) still blocklist as before.
- It utilises arr api every file while checking for existing file. May cause api spam to arrs.
---

## Screenshots (if applicable)
<!-- UI changes -->

---

## Checklist
- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct