### PR TITLE
fix(qbit): guard decodeAuthHeader against missing colon in decoded credentials

### DIFF
--- a/pkg/server/qbit/context.go
+++ b/pkg/server/qbit/context.go
@@ -57,6 +57,15 @@ func decodeAuthHeader(header string) (string, string, error) {
 	bearer := string(bytes)
 
 	colonIndex := strings.LastIndex(bearer, ":")
+	if colonIndex < 0 {
+		// strings.LastIndex returns -1 when the substring is absent; without
+		// this guard `bearer[:colonIndex]` would panic with
+		// "slice bounds out of range [:-1]". Triggers on any Authorization
+		// header whose decoded base64 payload contains no ':' separator
+		// (e.g. an empty payload, or garbage bytes that decode but lack a
+		// 'user:pass' shape).
+		return "", "", fmt.Errorf("malformed credentials: missing colon separator")
+	}
 	username := bearer[:colonIndex]
 	password := bearer[colonIndex+1:]
 

--- a/pkg/server/qbit/context_test.go
+++ b/pkg/server/qbit/context_test.go
@@ -1,0 +1,123 @@
+package qbit
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDecodeAuthHeader covers the fix for the slice-bounds-out-of-range panic
+// at pkg/server/qbit/context.go:60-62. When the base64-decoded payload contains
+// no colon, strings.LastIndex returns -1 and the subsequent slice expression
+// `bearer[:colonIndex]` panics with "slice bounds out of range [:-1]".
+//
+// Pre-fix the "no colon" cases panic; post-fix they return a clean error and
+// let the caller respond with 401 instead of crashing the request handler
+// (chi's Recoverer middleware catches the panic, but the goroutine traceback
+// is logged on every occurrence).
+func TestDecodeAuthHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		header       string
+		wantErr      bool
+		wantUser     string
+		wantPass     string
+		mustNotPanic bool // documents the regression we're guarding against
+	}{
+		{
+			name:     "well-formed Basic auth",
+			header:   "Basic " + b64("alice:hunter2"),
+			wantErr:  false,
+			wantUser: "alice",
+			wantPass: "hunter2",
+		},
+		{
+			name:     "well-formed with colon in password",
+			header:   "Basic " + b64("alice:hunt:er2"),
+			wantErr:  false,
+			wantUser: "alice:hunt", // strings.LastIndex => split on the last colon
+			wantPass: "er2",
+		},
+		{
+			// Empty payload — base64 of "" is "", decoded back is "". No colon.
+			// PRE-FIX: panic.
+			name:         "empty payload (the panic case)",
+			header:       "Basic ",
+			wantErr:      true,
+			mustNotPanic: true,
+		},
+		{
+			// Garbage that decodes successfully but has no colon.
+			// PRE-FIX: panic.
+			name:         "no-colon decoded bytes",
+			header:       "Basic " + b64("just-a-token-no-colon"),
+			wantErr:      true,
+			mustNotPanic: true,
+		},
+		{
+			// "Bearer xyz" splits to ["Bearer", "xyz"] (len == 2, so it doesn't
+			// take the early-return path). "xyz" then fails base64 decoding
+			// because the length isn't a multiple of 4 — surfaces as decode err.
+			name:    "non-Basic scheme (token not valid base64)",
+			header:  "Bearer xyz",
+			wantErr: true,
+		},
+		{
+			name:    "non-base64 payload",
+			header:  "Basic !!!not-base64!!!",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if tt.mustNotPanic {
+						t.Fatalf("decodeAuthHeader panicked on %q: %v (regression — function must return an error, not panic)", tt.header, r)
+					}
+					panic(r)
+				}
+			}()
+
+			user, pass, err := decodeAuthHeader(tt.header)
+
+			if tt.wantErr && err == nil {
+				t.Errorf("expected an error for header=%q, got nil (user=%q, pass=%q)", tt.header, user, pass)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for header=%q: %v", tt.header, err)
+			}
+			if tt.wantUser != "" && user != tt.wantUser {
+				t.Errorf("user mismatch: got %q want %q", user, tt.wantUser)
+			}
+			if tt.wantPass != "" && pass != tt.wantPass {
+				t.Errorf("pass mismatch: got %q want %q", pass, tt.wantPass)
+			}
+		})
+	}
+}
+
+// b64 encodes a string as standard base64 with padding. Tiny helper so the
+// test cases read like the wire format they represent.
+func b64(s string) string {
+	const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	src := []byte(s)
+	var sb strings.Builder
+	for i := 0; i < len(src); i += 3 {
+		var buf [3]byte
+		n := copy(buf[:], src[i:])
+		sb.WriteByte(alpha[buf[0]>>2])
+		sb.WriteByte(alpha[(buf[0]&0x03)<<4|buf[1]>>4])
+		if n > 1 {
+			sb.WriteByte(alpha[(buf[1]&0x0f)<<2|buf[2]>>6])
+		} else {
+			sb.WriteByte('=')
+		}
+		if n > 2 {
+			sb.WriteByte(alpha[buf[2]&0x3f])
+		} else {
+			sb.WriteByte('=')
+		}
+	}
+	return sb.String()
+}


### PR DESCRIPTION
Fixes #260.

## What this fixes

`decodeAuthHeader` in `pkg/server/qbit/context.go` panics with `slice bounds out of range [:-1]` when the base64-decoded `Authorization` payload contains no `:` separator.

Trigger: any Authorization header whose decoded bytes contain no `:`. Easy way to hit it is `Authorization: Basic ` (a single trailing space) which splits into two tokens, makes `encodedToken` empty, base64-decodes to empty `bearer`, and then `bearer[:-1]` panics. Also reachable with any garbled base64 that decodes successfully but lacks user:pass shape.

The panic is caught by chi's `Recoverer` middleware so the process keeps serving — but each occurrence dumps a goroutine traceback to stderr, and operators with log-based alerting see spurious "panic" matches that look like crashes. Also: `decodeAuthHeader` already errors on empty user/pass; this PR extends the same hygiene to malformed-shape inputs.

## The change

3-line nil-check before the slice (`pkg/server/qbit/context.go`):

```go
colonIndex := strings.LastIndex(bearer, ":")
if colonIndex < 0 {
    return "", "", fmt.Errorf("malformed credentials: missing colon separator")
}
username := bearer[:colonIndex]
password := bearer[colonIndex+1:]
```

## Test coverage

New table-test in `pkg/server/qbit/context_test.go` exercises:

| Case | Pre-fix | Post-fix |
|---|---|---|
| Well-formed `Basic <user:pass>` | passes | passes |
| `Basic <user:p:ass>` (LastIndex semantics — last colon splits) | passes | passes |
| **`Basic ` (empty payload, the panic case)** | **panics** | clean error |
| **`Basic <bytes-without-colon>`** | **panics** | clean error |
| `Bearer xyz` (non-Basic, bad base64) | error | error |
| `Basic !!!not-base64!!!` | error | error |

Run locally:

```
$ go test ./pkg/server/qbit/ -run TestDecodeAuthHeader -v
=== RUN   TestDecodeAuthHeader
    --- PASS: TestDecodeAuthHeader/well-formed_Basic_auth (0.00s)
    --- PASS: TestDecodeAuthHeader/well-formed_with_colon_in_password (0.00s)
    --- PASS: TestDecodeAuthHeader/empty_payload_(the_panic_case) (0.00s)
    --- PASS: TestDecodeAuthHeader/no-colon_decoded_bytes (0.00s)
    --- PASS: TestDecodeAuthHeader/non-Basic_scheme_(token_not_valid_base64) (0.00s)
    --- PASS: TestDecodeAuthHeader/non-base64_payload (0.00s)
PASS
ok  	github.com/sirrobot01/decypharr/pkg/server/qbit	0.009s
```

The two regression-guard rows (panic cases) include a `defer recover()` that fails the test if `decodeAuthHeader` panics, so they're a real regression test rather than a write-only check — running this test against `main` reproduces the bug; running it post-fix passes.

## Repro one-liner against a running container

```
$ curl -sf -o /dev/null -w "%{http_code}\n" -H 'Authorization: Basic ' http://localhost:8282/api/v2/torrents/info
# pre-fix: HTTP 500 + chi-recovered panic in container logs
# post-fix: HTTP 401, no panic
```

I've been running this fix in a homelab deploy for a few hours; smoke testing the original trigger no longer panics, everything continues to load and serve normally.