### PR TITLE
custom_folders: add category / not_category filter primitives

### DIFF
--- a/pkg/manager/custom_folders.go
+++ b/pkg/manager/custom_folders.go
@@ -35,6 +35,13 @@ const (
 	filterByFileCountLT   string = "file_count_lt"
 	filterByFilesRegex    string = "files_regex"
 	filterByNotFilesRegex string = "not_files_regex"
+
+	// Filters by qBit category (set by the *arr at torrent-add time, e.g.
+	// "tv-sonarr" / "radarr" / a Whisparr-side name). Lets virtual folders
+	// scope to "torrents added by a specific *arr" without any external
+	// tagging — Category is already a hot field on the in-memory IndexEntry.
+	filterByCategory    string = "category"
+	filterByNotCategory string = "not_category"
 )
 
 type CustomFolders struct {
@@ -84,7 +91,8 @@ func (m *Manager) GetCustomFolders() []string {
 
 // matchesFilter checks if a torrent matches all filters for a folder.
 // getFileNames is a lazy loader called only when files_regex/not_files_regex/file_count filters are needed.
-func (cf *CustomFolders) matchesFilter(folderName string, fileInfo os.FileInfo, addedTime time.Time, getFileNames func() []string) bool {
+// category is the qBit category set at torrent-add time (typically the *arr name); empty string means unknown.
+func (cf *CustomFolders) matchesFilter(folderName string, fileInfo os.FileInfo, addedTime time.Time, category string, getFileNames func() []string) bool {
 	filters, ok := cf.filters[folderName]
 	if !ok {
 		return false
@@ -137,7 +145,7 @@ func (cf *CustomFolders) matchesFilter(folderName string, fileInfo os.FileInfo, 
 	} else {
 		// Single type present — AND logic
 		for _, filter := range append(regexFilters, filesRegexFilters...) {
-			if !cf.checkSingleFilter(filter, fileInfo, addedTime, getFileNames) {
+			if !cf.checkSingleFilter(filter, fileInfo, addedTime, category, getFileNames) {
 				return false
 			}
 		}
@@ -145,7 +153,7 @@ func (cf *CustomFolders) matchesFilter(folderName string, fileInfo os.FileInfo, 
 
 	// All other filters AND match
 	for _, filter := range otherFilters {
-		if !cf.checkSingleFilter(filter, fileInfo, addedTime, getFileNames) {
+		if !cf.checkSingleFilter(filter, fileInfo, addedTime, category, getFileNames) {
 			return false
 		}
 	}
@@ -154,7 +162,7 @@ func (cf *CustomFolders) matchesFilter(folderName string, fileInfo os.FileInfo, 
 }
 
 // checkSingleFilter checks if a single filter matches
-func (cf *CustomFolders) checkSingleFilter(filter directoryFilter, fileInfo os.FileInfo, addedTime time.Time, getFileNames func() []string) bool {
+func (cf *CustomFolders) checkSingleFilter(filter directoryFilter, fileInfo os.FileInfo, addedTime time.Time, category string, getFileNames func() []string) bool {
 	name := fileInfo.Name()
 	size := fileInfo.Size()
 
@@ -203,6 +211,12 @@ func (cf *CustomFolders) checkSingleFilter(filter directoryFilter, fileInfo os.F
 			}
 		}
 		return true
+	case filterByCategory:
+		// Exact-match on the qBit category set at add-time. Useful for
+		// scoping a virtual folder to torrents from a specific *arr.
+		return category == filter.value
+	case filterByNotCategory:
+		return category != filter.value
 	default:
 		return false
 	}

--- a/pkg/manager/custom_folders_test.go
+++ b/pkg/manager/custom_folders_test.go
@@ -1,0 +1,145 @@
+package manager
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// stubFileInfo lets tests construct an os.FileInfo without touching the
+// filesystem. Mirrors what entry.go's FileInfo does in production but stays
+// local to keep the test self-contained.
+type stubFileInfo struct {
+	name string
+	size int64
+}
+
+func (f *stubFileInfo) Name() string       { return f.name }
+func (f *stubFileInfo) Size() int64        { return f.size }
+func (f *stubFileInfo) Mode() os.FileMode  { return 0 }
+func (f *stubFileInfo) ModTime() time.Time { return time.Time{} }
+func (f *stubFileInfo) IsDir() bool        { return true }
+func (f *stubFileInfo) Sys() any           { return nil }
+
+// TestMatchesFilterCategory covers the new filterByCategory / filterByNotCategory
+// primitives. The whole point: let a virtual folder say "show me only torrents
+// added by Sonarr" via `filters: {category: "tv-sonarr"}` without inventing
+// any out-of-band metadata — Category is already on every torrent in the
+// IndexEntry, set when the *arr POSTs to the qBit add endpoint.
+func TestMatchesFilterCategory(t *testing.T) {
+	tests := []struct {
+		name       string
+		folderName string
+		filterType string
+		filterVal  string
+		torrentCat string
+		want       bool
+	}{
+		{
+			name:       "category match — sonarr torrent in sonarr folder",
+			folderName: "sonarr",
+			filterType: filterByCategory,
+			filterVal:  "tv-sonarr",
+			torrentCat: "tv-sonarr",
+			want:       true,
+		},
+		{
+			name:       "category mismatch — radarr torrent excluded from sonarr folder",
+			folderName: "sonarr",
+			filterType: filterByCategory,
+			filterVal:  "tv-sonarr",
+			torrentCat: "radarr",
+			want:       false,
+		},
+		{
+			name:       "empty category never matches a non-empty filter",
+			folderName: "sonarr",
+			filterType: filterByCategory,
+			filterVal:  "tv-sonarr",
+			torrentCat: "",
+			want:       false,
+		},
+		{
+			name:       "not_category — torrent NOT in radarr does match",
+			folderName: "non-radarr",
+			filterType: filterByNotCategory,
+			filterVal:  "radarr",
+			torrentCat: "tv-sonarr",
+			want:       true,
+		},
+		{
+			name:       "not_category — torrent IS radarr does not match",
+			folderName: "non-radarr",
+			filterType: filterByNotCategory,
+			filterVal:  "radarr",
+			torrentCat: "radarr",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf := &CustomFolders{
+				filters: map[string][]directoryFilter{
+					tt.folderName: {
+						{filterType: tt.filterType, value: tt.filterVal},
+					},
+				},
+				folders: []string{tt.folderName},
+			}
+			got := cf.matchesFilter(
+				tt.folderName,
+				&stubFileInfo{name: "Some.Release.Name.S01E01.mkv", size: 1024},
+				time.Now(),
+				tt.torrentCat,
+				func() []string { return nil },
+			)
+			if got != tt.want {
+				t.Errorf("matchesFilter(folder=%q, %s=%q, torrentCat=%q) = %v, want %v",
+					tt.folderName, tt.filterType, tt.filterVal, tt.torrentCat, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMatchesFilterCategoryInteractsWithOtherFilters verifies category as part
+// of an AND-stack with other filter primitives. A "sonarr 4K only" virtual
+// folder should match Sonarr+4K and reject Sonarr+1080p / Radarr+4K.
+func TestMatchesFilterCategoryInteractsWithOtherFilters(t *testing.T) {
+	cf := &CustomFolders{
+		filters: map[string][]directoryFilter{
+			"sonarr-4k": {
+				{filterType: filterByCategory, value: "tv-sonarr"},
+				{filterType: filterByInclude, value: "2160p"},
+			},
+		},
+		folders: []string{"sonarr-4k"},
+	}
+
+	tests := []struct {
+		name       string
+		releaseName string
+		category   string
+		want       bool
+	}{
+		{"Sonarr + 2160p — match", "Show.S01E01.2160p.WEB.x265.mkv", "tv-sonarr", true},
+		{"Sonarr + 1080p — reject (size filter fails)", "Show.S01E01.1080p.WEB.x264.mkv", "tv-sonarr", false},
+		{"Radarr + 2160p — reject (category filter fails)", "Movie.2024.2160p.BluRay.x265.mkv", "radarr", false},
+		{"Empty category + 2160p — reject", "Anon.Release.2160p.mkv", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cf.matchesFilter(
+				"sonarr-4k",
+				&stubFileInfo{name: tt.releaseName, size: 4_000_000_000},
+				time.Now(),
+				tt.category,
+				func() []string { return nil },
+			)
+			if got != tt.want {
+				t.Errorf("matchesFilter(release=%q, cat=%q) = %v, want %v", tt.releaseName, tt.category, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/manager/entry.go
+++ b/pkg/manager/entry.go
@@ -522,7 +522,7 @@ func (m *Manager) getCustomFolderChildren(folder string) []FileInfo {
 		if m.customFolders.matchesFilter(folder, &FileInfo{
 			name: meta.Name,
 			size: meta.Size,
-		}, meta.AddedOn, getFileNames) {
+		}, meta.AddedOn, meta.Category, getFileNames) {
 			if _, ok := seen[meta.Name]; ok {
 				return nil
 			}

--- a/pkg/storage/entry.go
+++ b/pkg/storage/entry.go
@@ -131,6 +131,7 @@ type EntryMetaInfo struct {
 	AddedOn  time.Time
 	Provider string
 	Protocol string
+	Category string // qBit category set at add time (typically the arr name: "tv-sonarr", "radarr", etc.)
 	Bad      bool
 }
 
@@ -145,6 +146,7 @@ func (s *Storage) ForEachMeta(fn func(*EntryMetaInfo) error) error {
 			AddedOn:  time.Unix(meta.AddedOn, 0),
 			Provider: meta.Provider,
 			Protocol: meta.Protocol,
+			Category: meta.Category,
 			Bad:      meta.Bad,
 		})
 	})


### PR DESCRIPTION
## Summary

Adds two filter primitives — `category` and `not_category` — to the Virtual Folders feature, letting a folder scope to torrents added by a specific *arr without any out-of-band metadata.

The qBit category set by the *arr at torrent-add time is already a hot field on `IndexEntry` (populated in `pkg/server/qbit/http.go`). This change just exposes it to the existing virtual-folder filter chain.

## Why

A common ask is "show me only the torrents Sonarr added" or "everything Radarr added except 4K" as a virtual folder. The metadata is already there; the filter language just couldn't reference it.

With this PR, configs like the following work:

```jsonc
"custom_folders": {
  "sonarr":   { "filters": { "category": "tv-sonarr" } },
  "radarr":   { "filters": { "category": "radarr" } },
  "whisparr": { "filters": { "category": "backup" } },
  "non-radarr": { "filters": { "not_category": "radarr" } }
}
```

`category` interacts cleanly with the existing AND-stack — e.g. a "Sonarr + 2160p" folder is just `{ "category": "tv-sonarr", "include": "2160p" }`.

## What changed

- `pkg/manager/custom_folders.go` — two new filter constants (`filterByCategory`, `filterByNotCategory`); `matchesFilter` and `checkSingleFilter` take a new `category` parameter; two case branches do exact-match / negated-match against the torrent's `Category`.
- `pkg/storage/entry.go` — surface `Category` on `EntryMetaInfo` so the metadata-only iterator (`ForEachMeta`) can pass it without a disk read. The field is already on `IndexEntry`, so no new state.
- `pkg/manager/entry.go` — the single call site in `getCustomFolderChildren` passes `meta.Category`.
- `pkg/manager/custom_folders_test.go` — table tests for: simple match / mismatch, empty-category rejection (an empty Category never matches a non-empty filter), `not_category` positive + negative, and category in an AND-stack with `include` (Sonarr+2160p match, Sonarr+1080p reject, Radarr+2160p reject, empty+2160p reject).

Empty-category behavior is intentional and tested: a torrent with no category never matches a `category: "X"` filter (`"" == "tv-sonarr"` is false), so older torrents that predate qBit category tracking simply don't show up in category-filtered folders — they remain visible under `__all__`, the per-provider folder, and any non-category virtual folder.

## Test plan

- [x] `go test ./pkg/manager/... -run TestMatchesFilterCategory` — all 9 new cases pass
- [x] `go test ./...` — full suite green
- [x] Built locally and validated end-to-end against a live cache:
  - `sonarr` folder (filter `category: tv-sonarr`) returned 394 torrents
  - `radarr` folder (filter `category: radarr`) returned 69 torrents
  - Spot-checked entries against `torrents.json` to confirm the category labels match

## Notes for the reviewer

- No config-schema change beyond accepting two new filter-type strings; existing virtual-folder configs continue to work unchanged.
- The new `category` parameter is threaded through `matchesFilter` / `checkSingleFilter` — there is exactly one call site (the metadata-only iterator in `getCustomFolderChildren`), and the signature change is local to the manager package.
- I'm separately running a small one-shot backfill on my deploy that fills in `IndexEntry.Category` for entries created before this field was tracked, by reading qBit's `torrents.json`. That's not part of this PR — happy to send it as a follow-up if it's useful upstream.