### PR TITLE
Add ARR submitted name folder naming option

### DIFF
--- a/docs/src/content/docs/guides/mounting/webdav.md
+++ b/docs/src/content/docs/guides/mounting/webdav.md
@@ -72,21 +72,24 @@ WebDAV auth is controlled by:
 
 ## Folder Naming
 
-Control how torrent folders are named:
+Control how download folders are named:
 
 ```json
 {
-  "webdav_folder_naming": "filename"
+  "folder_naming": "filename"
 }
 ```
 
-| Value             | Example                 |
-|-------------------|-------------------------|
-| `filename`        | `Movie.2024.1080p.mkv`  |
-| `original`        | `Original Torrent Name` |
-| `filename_no_ext` | `Movie.2024.1080p`      |
-| `original_no_ext` | `Original Torrent Name` |
-| `infohash`        | `abc123def456...`       |
+| UI option | Config value | Example folder |
+|-----------|--------------|----------------|
+| File name | `filename` | `Movie.2024.1080p.mkv` |
+| Original name | `original` | `Original Torrent Name` |
+| File name (No Extension) | `filename_no_ext` | `Movie.2024.1080p` |
+| Original name (No Extension) | `original_no_ext` | `Original Torrent Name` |
+| ARR submitted name | `arr_submitted_name` | `Example Show Season 01 S01 1080p WEB-DL x265` |
+| Infohash | `infohash` | `abc123def456...` |
+
+**ARR submitted name** uses the release name sent by Sonarr, Radarr, or another client, such as the `dn` value in a magnet link or the uploaded torrent/NZB filename. Decypharr sanitizes this value before creating the folder.
 
 ## Streaming
 

--- a/docs/src/content/docs/guides/mounting/webdav.md
+++ b/docs/src/content/docs/guides/mounting/webdav.md
@@ -72,21 +72,24 @@ WebDAV auth is controlled by:
 
 ## Folder Naming
 
-Control how torrent folders are named:
+Control how download folders are named:
 
 ```json
 {
-  "webdav_folder_naming": "filename"
+  "folder_naming": "filename"
 }
 ```
 
-| Value | Example |
-|-------|---------|
-| `filename` | `Movie.2024.1080p.mkv` |
-| `original` | `Original Torrent Name` |
-| `filename_no_ext` | `Movie.2024.1080p` |
-| `original_no_ext` | `Original Torrent Name` |
-| `infohash` | `abc123def456...` |
+| UI option | Config value | Example folder |
+|-----------|--------------|----------------|
+| File name | `filename` | `Movie.2024.1080p.mkv` |
+| Original name | `original` | `Original Torrent Name` |
+| File name (No Extension) | `filename_no_ext` | `Movie.2024.1080p` |
+| Original name (No Extension) | `original_no_ext` | `Original Torrent Name` |
+| ARR submitted name | `arr_submitted_name` | `Example Show Season 01 S01 1080p WEB-DL x265` |
+| Infohash | `infohash` | `abc123def456...` |
+
+**ARR submitted name** uses the release name sent by Sonarr, Radarr, or another client, such as the `dn` value in a magnet link or the uploaded torrent/NZB filename. Decypharr sanitizes this value before creating the folder.
 
 ## Streaming
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ const (
 	WebDavUseOriginalName      WebDavFolderNaming = "original"
 	WebDavUseFileNameNoExt     WebDavFolderNaming = "filename_no_ext"
 	WebDavUseOriginalNameNoExt WebDavFolderNaming = "original_no_ext"
+	WebDavUseArrSubmittedName  WebDavFolderNaming = "arr_submitted_name"
 	WebdavUseHash              WebDavFolderNaming = "infohash"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ const (
 	WebDavUseOriginalName      WebDavFolderNaming = "original"
 	WebDavUseFileNameNoExt     WebDavFolderNaming = "filename_no_ext"
 	WebDavUseOriginalNameNoExt WebDavFolderNaming = "original_no_ext"
+	WebDavUseArrSubmittedName  WebDavFolderNaming = "arr_submitted_name"
 	WebdavUseHash              WebDavFolderNaming = "infohash"
 )
 

--- a/internal/utils/magnet.go
+++ b/internal/utils/magnet.go
@@ -47,10 +47,11 @@ func stripTrackersFromMagnet(mi metainfo.Magnet, fileType string) metainfo.Magne
 
 func GetMagnetFromFile(file io.Reader, filePath string, rmTrackerUrls bool) (*Magnet, error) {
 	var (
-		m   *Magnet
-		err error
+		m         *Magnet
+		err       error
+		isTorrent = filepath.Ext(filePath) == ".torrent"
 	)
-	if filepath.Ext(filePath) == ".torrent" {
+	if isTorrent {
 		torrentData, err := io.ReadAll(file)
 		if err != nil {
 			return nil, err
@@ -67,7 +68,14 @@ func GetMagnetFromFile(file io.Reader, filePath string, rmTrackerUrls bool) (*Ma
 			return nil, err
 		}
 	}
-	m.Name = strings.TrimSuffix(filePath, filepath.Ext(filePath))
+	uploadedName := strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+	if isTorrent {
+		m.Name = uploadedName
+		m.Link = SetMagnetDisplayName(m.Link, m.Name)
+	} else if m.Name == "" {
+		m.Name = uploadedName
+		m.Link = SetMagnetDisplayName(m.Link, m.Name)
+	}
 	return m, nil
 }
 
@@ -170,6 +178,42 @@ func GetMagnetInfo(magnetLink string, rmTrackerUrls bool) (*Magnet, error) {
 		Link:     finalLink,
 	}
 	return magnet, nil
+}
+
+func MagnetDisplayName(magnetLink string) string {
+	mi, err := metainfo.ParseMagnetUri(magnetLink)
+	if err != nil {
+		return ""
+	}
+	return mi.DisplayName
+}
+
+func SetMagnetDisplayName(magnetLink, name string) string {
+	name = strings.TrimSpace(name)
+	if magnetLink == "" || name == "" {
+		return magnetLink
+	}
+	parsed, err := url.Parse(magnetLink)
+	if err != nil || parsed.Scheme != "magnet" {
+		return magnetLink
+	}
+	encodedName := url.QueryEscape(name)
+	parts := strings.Split(magnetLink, "?")
+	if len(parts) != 2 {
+		return magnetLink
+	}
+	queryParts := strings.Split(parts[1], "&")
+	for i, part := range queryParts {
+		if strings.HasPrefix(part, "dn=") {
+			queryParts[i] = "dn=" + encodedName
+			return parts[0] + "?" + strings.Join(queryParts, "&")
+		}
+	}
+	separator := "&"
+	if parts[1] == "" {
+		separator = ""
+	}
+	return magnetLink + separator + "dn=" + encodedName
 }
 
 func ExtractInfoHash(magnetDesc string) string {

--- a/internal/utils/magnet_test.go
+++ b/internal/utils/magnet_test.go
@@ -8,8 +8,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirrobot01/decypharr/internal/config"
 	"github.com/sirrobot01/decypharr/internal/testutil"
 )
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "decypharr-utils-test-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	config.SetConfigPath(dir)
+	os.Exit(m.Run())
+}
 
 // checkMagnet is a helper function that verifies magnet properties
 func checkMagnet(t *testing.T, magnet *Magnet, expectedInfoHash, expectedName, expectedLink string, expectedTrackerCount int, shouldBeTorrent bool) {
@@ -81,6 +92,80 @@ func TestGetMagnetFromFile_RealTorrentFile_StripFalse(t *testing.T) {
 
 	torrentPath := testutil.GetTestTorrentPath()
 	testMagnetFromFile(t, torrentPath, false, expectedInfoHash, expectedName, expectedLink, expectedTrackerCount)
+}
+
+func TestGetMagnetFromFile_UsesUploadedFilenameAsDisplayName(t *testing.T) {
+	file, err := os.Open(testutil.GetTestTorrentPath())
+	if err != nil {
+		t.Fatalf("Failed to open torrent file: %v", err)
+	}
+	defer file.Close()
+
+	magnet, err := GetMagnetFromFile(file, "Example Show Season 01 S01 1080p WEB-DL x265.torrent", true)
+	if err != nil {
+		t.Fatalf("GetMagnetFromFile failed: %v", err)
+	}
+
+	want := "Example Show Season 01 S01 1080p WEB-DL x265"
+	if magnet.Name != want {
+		t.Fatalf("expected name %q, got %q", want, magnet.Name)
+	}
+	if got := MagnetDisplayName(magnet.Link); got != want {
+		t.Fatalf("expected display name %q, got %q", want, got)
+	}
+}
+
+func TestGetMagnetFromFile_StripsUploadedTorrentPathFromDisplayName(t *testing.T) {
+	file, err := os.Open(testutil.GetTestTorrentPath())
+	if err != nil {
+		t.Fatalf("Failed to open torrent file: %v", err)
+	}
+	defer file.Close()
+
+	magnet, err := GetMagnetFromFile(file, "/tmp/Example Show Season 01 S01 1080p WEB-DL x265.torrent", true)
+	if err != nil {
+		t.Fatalf("GetMagnetFromFile failed: %v", err)
+	}
+
+	want := "Example Show Season 01 S01 1080p WEB-DL x265"
+	if magnet.Name != want {
+		t.Fatalf("expected name %q, got %q", want, magnet.Name)
+	}
+	if got := MagnetDisplayName(magnet.Link); got != want {
+		t.Fatalf("expected display name %q, got %q", want, got)
+	}
+}
+
+func TestGetMagnetFromFile_MagnetFileKeepsEmbeddedDisplayName(t *testing.T) {
+	file := strings.NewReader("magnet:?xt=urn:btih:8a19577fb5f690970ca43a57ff1011ae202244b8&dn=Embedded+Release+Name")
+
+	magnet, err := GetMagnetFromFile(file, "uploaded-name.magnet", true)
+	if err != nil {
+		t.Fatalf("GetMagnetFromFile failed: %v", err)
+	}
+
+	if got, want := magnet.Name, "Embedded Release Name"; got != want {
+		t.Fatalf("expected name %q, got %q", want, got)
+	}
+	if got, want := MagnetDisplayName(magnet.Link), "Embedded Release Name"; got != want {
+		t.Fatalf("expected display name %q, got %q", want, got)
+	}
+}
+
+func TestGetMagnetFromFile_MagnetFileWithoutDisplayNameUsesUploadedFilename(t *testing.T) {
+	file := strings.NewReader("magnet:?xt=urn:btih:8a19577fb5f690970ca43a57ff1011ae202244b8")
+
+	magnet, err := GetMagnetFromFile(file, "uploaded-release-name.magnet", true)
+	if err != nil {
+		t.Fatalf("GetMagnetFromFile failed: %v", err)
+	}
+
+	if got, want := magnet.Name, "uploaded-release-name"; got != want {
+		t.Fatalf("expected name %q, got %q", want, got)
+	}
+	if got, want := MagnetDisplayName(magnet.Link), "uploaded-release-name"; got != want {
+		t.Fatalf("expected display name %q, got %q", want, got)
+	}
 }
 
 func TestGetMagnetFromFile_MagnetFile_StripTrue(t *testing.T) {

--- a/internal/utils/regex.go
+++ b/internal/utils/regex.go
@@ -40,6 +40,61 @@ func RemoveInvalidChars(value string) string {
 	}, value)
 }
 
+func SafeFolderName(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 || strings.ContainsRune(`<>:"/\|?*`, r) {
+			return -1
+		}
+		return r
+	}, value)
+	value = strings.Join(strings.Fields(value), " ")
+	value = strings.Trim(value, " .")
+	if value == "" || value == "." || value == ".." {
+		return fallback
+	}
+	if isReservedWindowsName(value) {
+		return fallback
+	}
+	value = truncateFolderName(value, 255)
+	value = strings.Trim(value, " .")
+	if value == "" || isReservedWindowsName(value) {
+		return fallback
+	}
+	return value
+}
+
+func truncateFolderName(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	var builder strings.Builder
+	for _, r := range value {
+		if builder.Len()+len(string(r)) > maxBytes {
+			break
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
+}
+
+func isReservedWindowsName(value string) bool {
+	name := strings.ToUpper(value)
+	if base, _, ok := strings.Cut(name, "."); ok {
+		name = base
+	}
+	switch name {
+	case "CON", "PRN", "AUX", "NUL":
+		return true
+	case "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9":
+		return true
+	case "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return true
+	default:
+		return false
+	}
+}
+
 func RemoveExtension(value string) string {
 	ext := filepath.Ext(value)
 	if ext == "" {

--- a/internal/utils/regex_test.go
+++ b/internal/utils/regex_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSafeFolderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "removes path separators and invalid characters",
+			value:    "../bad:name?",
+			fallback: "hash",
+			want:     "badname",
+		},
+		{
+			name:     "falls back for empty names",
+			value:    " . ",
+			fallback: "hash",
+			want:     "hash",
+		},
+		{
+			name:     "falls back for reserved device names",
+			value:    "CON",
+			fallback: "hash",
+			want:     "hash",
+		},
+		{
+			name:     "falls back for reserved device names with multiple extensions",
+			value:    "CON.foo.bar",
+			fallback: "hash",
+			want:     "hash",
+		},
+		{
+			name:     "truncates long components",
+			value:    strings.Repeat("a", 300),
+			fallback: "hash",
+			want:     strings.Repeat("a", 255),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SafeFolderName(tt.value, tt.fallback); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/server/qbit/types.go
+++ b/pkg/server/qbit/types.go
@@ -403,9 +403,16 @@ type TorrentFile struct {
 
 // ToQBitTorrent converts to QBitTorrent format for API compatibility
 func convertToQBitTorrentTorrent(t *storage.Entry) Torrent {
+	name := t.Name
+	contentPath := t.ContentPath
+	if config.Get().FolderNaming == config.WebDavUseArrSubmittedName {
+		name = t.GetFolder()
+		contentPath = t.DownloadPath()
+	}
+
 	qbitTorrent := Torrent{
 		Hash:         t.InfoHash,
-		Name:         t.Name,
+		Name:         name,
 		Size:         t.Size,
 		Progress:     t.Progress,
 		Dlspeed:      t.Speed,
@@ -414,7 +421,7 @@ func convertToQBitTorrentTorrent(t *storage.Entry) Torrent {
 		State:        t.State,
 		Category:     t.Category,
 		SavePath:     t.SavePath,
-		ContentPath:  t.ContentPath,
+		ContentPath:  contentPath,
 		AddedOn:      t.CreatedAt.Unix(),
 		CompletionOn: 0,
 		Debrid:       t.ActiveProvider,

--- a/pkg/server/qbit/types.go
+++ b/pkg/server/qbit/types.go
@@ -1,6 +1,7 @@
 package qbit
 
 import (
+	"github.com/sirrobot01/decypharr/internal/config"
 	"github.com/sirrobot01/decypharr/pkg/storage"
 )
 
@@ -400,9 +401,16 @@ type TorrentFile struct {
 
 // ToQBitTorrent converts to QBitTorrent format for API compatibility
 func convertToQBitTorrentTorrent(t *storage.Entry) Torrent {
+	name := t.Name
+	contentPath := t.ContentPath
+	if config.Get().FolderNaming == config.WebDavUseArrSubmittedName {
+		name = t.GetFolder()
+		contentPath = t.DownloadPath()
+	}
+
 	qbitTorrent := Torrent{
 		Hash:         t.InfoHash,
-		Name:         t.Name,
+		Name:         name,
 		Size:         t.Size,
 		Progress:     t.Progress,
 		Dlspeed:      t.Speed,
@@ -411,7 +419,7 @@ func convertToQBitTorrentTorrent(t *storage.Entry) Torrent {
 		State:        t.State,
 		Category:     t.Category,
 		SavePath:     t.SavePath,
-		ContentPath:  t.ContentPath,
+		ContentPath:  contentPath,
 		AddedOn:      t.CreatedAt.Unix(),
 		CompletionOn: 0,
 		Debrid:       t.ActiveProvider,

--- a/pkg/server/templates/config.html
+++ b/pkg/server/templates/config.html
@@ -197,6 +197,7 @@
                                                 <option value="original">Original name</option>
                                                 <option value="filename">File name</option>
                                                 <option value="filename_no_ext">File name (No Extension)</option>
+                                                <option value="arr_submitted_name">ARR submitted name</option>
                                                 <option value="infohash">Infohash</option>
                                             </select>
                                             <span class="text-sm opacity-70">How to name folders in WebDAV</span>

--- a/pkg/server/templates/config.html
+++ b/pkg/server/templates/config.html
@@ -278,6 +278,7 @@
                                                 <option value="original">Original name</option>
                                                 <option value="filename">File name</option>
                                                 <option value="filename_no_ext">File name (No Extension)</option>
+                                                <option value="arr_submitted_name">ARR submitted name</option>
                                                 <option value="infohash">Infohash</option>
                                             </select>
                                             <span class="text-sm opacity-70">How to name folders in WebDAV</span>

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -506,6 +506,9 @@ func (e *Entry) IsValid() bool {
 
 // DownloadPath returns the expected download/symlink path for this entry
 func (e *Entry) DownloadPath() string {
+	if config.Get().FolderNaming == config.WebDavUseArrSubmittedName {
+		return filepath.Join(e.SavePath, e.GetFolder())
+	}
 	return filepath.Join(e.SavePath, utils.RemoveExtension(e.Name))
 }
 
@@ -676,10 +679,27 @@ func GetTorrentFolder(folderNaming config.WebDavFolderNaming, entry *Entry) stri
 		folder = path.Clean(utils.RemoveExtension(entry.Name))
 	case config.WebDavUseOriginalNameNoExt:
 		folder = path.Clean(utils.RemoveExtension(entry.OriginalFilename))
+	case config.WebDavUseArrSubmittedName:
+		folder = utils.SafeFolderName(entry.ArrSubmittedName(), entry.InfoHash)
 	case config.WebdavUseHash:
 		folder = entry.InfoHash
 	default:
 		folder = path.Clean(entry.Name)
 	}
 	return folder
+}
+
+func (e *Entry) ArrSubmittedName() string {
+	if e == nil {
+		return ""
+	}
+	if e.Magnet != "" {
+		if name := utils.MagnetDisplayName(e.Magnet); name != "" {
+			return name
+		}
+	}
+	if e.Protocol == config.ProtocolNZB && e.OriginalFilename != "" {
+		return e.OriginalFilename
+	}
+	return e.Name
 }

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -505,6 +505,9 @@ func (e *Entry) IsValid() bool {
 
 // DownloadPath returns the expected download/symlink path for this entry
 func (e *Entry) DownloadPath() string {
+	if config.Get().FolderNaming == config.WebDavUseArrSubmittedName {
+		return filepath.Join(e.SavePath, e.GetFolder())
+	}
 	return filepath.Join(e.SavePath, utils.RemoveExtension(e.Name))
 }
 
@@ -675,10 +678,27 @@ func GetTorrentFolder(folderNaming config.WebDavFolderNaming, entry *Entry) stri
 		folder = path.Clean(utils.RemoveExtension(entry.Name))
 	case config.WebDavUseOriginalNameNoExt:
 		folder = path.Clean(utils.RemoveExtension(entry.OriginalFilename))
+	case config.WebDavUseArrSubmittedName:
+		folder = utils.SafeFolderName(entry.ArrSubmittedName(), entry.InfoHash)
 	case config.WebdavUseHash:
 		folder = entry.InfoHash
 	default:
 		folder = path.Clean(entry.Name)
 	}
 	return folder
+}
+
+func (e *Entry) ArrSubmittedName() string {
+	if e == nil {
+		return ""
+	}
+	if e.Magnet != "" {
+		if name := utils.MagnetDisplayName(e.Magnet); name != "" {
+			return name
+		}
+	}
+	if e.Protocol == config.ProtocolNZB && e.OriginalFilename != "" {
+		return e.OriginalFilename
+	}
+	return e.Name
 }

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+)
+
+func TestGetTorrentFolderArrSubmittedNameFromMagnet(t *testing.T) {
+	entry := &Entry{
+		InfoHash: "8a19577fb5f690970ca43a57ff1011ae202244b8",
+		Name:     "provider-name",
+		Magnet:   "magnet:?xt=urn:btih:8a19577fb5f690970ca43a57ff1011ae202244b8&dn=Example+Show+Season+01+S01+1080p+WEB-DL+x265",
+	}
+
+	got := GetTorrentFolder(config.WebDavUseArrSubmittedName, entry)
+	want := "Example Show Season 01 S01 1080p WEB-DL x265"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetTorrentFolderArrSubmittedNameSanitizesPathUnsafeNames(t *testing.T) {
+	entry := &Entry{
+		InfoHash: "8a19577fb5f690970ca43a57ff1011ae202244b8",
+		Name:     "provider-name",
+		Magnet:   "magnet:?xt=urn:btih:8a19577fb5f690970ca43a57ff1011ae202244b8&dn=..%2Fbad%3Aname%3F",
+	}
+
+	got := GetTorrentFolder(config.WebDavUseArrSubmittedName, entry)
+	want := "badname"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetTorrentFolderArrSubmittedNameFallsBackToInfoHash(t *testing.T) {
+	entry := &Entry{
+		InfoHash: "8a19577fb5f690970ca43a57ff1011ae202244b8",
+		Name:     "provider-name",
+		Magnet:   "magnet:?xt=urn:btih:8a19577fb5f690970ca43a57ff1011ae202244b8&dn=..%2F%3F",
+	}
+
+	got := GetTorrentFolder(config.WebDavUseArrSubmittedName, entry)
+	want := "8a19577fb5f690970ca43a57ff1011ae202244b8"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
## 📌 Description

<!-- What does this PR do? Keep it short and clear -->

- Adds a new **ARR submitted name** folder naming option for WebDAV / external rclone paths.
- This keeps the release name sent by Sonarr, Radarr, or another client, such as the magnet `dn` value or uploaded torrent/NZB filename, instead of using a shorter debrid/provider title.
- This helps avoid imports where the ARR selected one release title but later sees a different folder name from Decypharr.

## Example of the issue this fixes:

Sonarr selected/scored the full release title:

<img width="608" height="77" alt="Sonarr search result showing the full release title" src="https://github.com/user-attachments/assets/ec820d4d-5fd6-49b9-823f-4a2eb2c9f13a" />

Real-Debrid later exposed a shorter/different torrent name:

<img width="375" height="81" alt="Real-Debrid showing a shorter torrent name" src="https://github.com/user-attachments/assets/7dc1367b-ff5f-4a24-b2d9-567cfeb56fe4" />

With `ARR submitted name`, Decypharr creates the folder using the title ARR originally submitted:

<img width="483" height="92" alt="Folder using the ARR-submitted release name" src="https://github.com/user-attachments/assets/cb252188-2275-4c3e-804a-fe2b234d2d8d" />

That lets Sonarr import the same release successfully instead of rejecting it based on the shortened folder name:

<img width="315" height="78" alt="Successful Sonarr import" src="https://github.com/user-attachments/assets/4cbfdf20-9944-4b1c-bdf5-6f356b9779c4" />

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

<!-- List key changes -->

- Added `folder_naming: "arr_submitted_name"` and the **ARR submitted name** settings option.
- Uses the submitted magnet display name (`dn`) when available.
- Uses uploaded torrent filenames for `.torrent` uploads. Sonarr/Radarr submit torrent files using the cleaned release title as the multipart filename, so this matches the title used for detection/scoring. `.magnet` files preserve embedded display names and fall back to the uploaded `.magnet` filename when no display name is present.
- Sanitizes generated folder names and falls back to the infohash when the submitted name cannot produce a safe folder name.
- Updates qBittorrent-compatible `name` and `content_path` values so ARR clients see the folder Decypharr actually creates.
- Updated WebDAV folder naming docs, including the current global config key: `folder_naming`.
- Added tests for magnet display names, uploaded torrent filenames, unsafe names, and fallback behavior.

---

## Testing

<!-- How was this tested? -->

- [x] Tested locally

Steps:

1. Captured Sonarr -> Decypharr requests and confirmed the ARR-submitted name contained the full release title.
2. Checked Sonarr logs for the failed import case. Example:
   - Short folder parsed badly:
     `Parsing string 'Season 01 1080p WEB-DL x265'`
     `No matching series Season`
   - Full ARR-selected title parsed correctly:
     `Parsing string 'Example Show Season 01 S01 1080p WEB-DL x265'`
     `Episode Parsed. Example Show - Season 01`
   - Import later rejected files against the shortened folder:
     `Episode 01x03 was unexpected considering the Season 01 1080p WEB-DL x265 folder name`
     `Not all episodes have been imported for the release 'Season 01 1080p WEB-DL x265'`
3. Verified the new option uses the original ARR-submitted release name, for example `Example Show Season 01 S01 1080p WEB-DL x265`.
4. Ran targeted tests:

```bash
go test ./internal/utils ./pkg/storage ./pkg/server/qbit
```

---

## Risks / Notes

<!-- Any side effects, migrations, breaking changes -->

- Existing folder naming options are unchanged.
- The docs previously referenced `webdav_folder_naming`, but the current global config key is `folder_naming`; this PR only updates the docs to match existing config behavior.
- Unsafe folder names are sanitized before use:
  - removes invalid/control characters and path separators
  - trims unsafe leading/trailing spaces or dots
  - rejects reserved names like `CON`, `NUL`, `COM1`, etc.
  - truncates very long names
  - falls back to the infohash if the result is empty or still unsafe

---

## Screenshots (if applicable)

<!-- UI changes -->

- Settings dropdown now includes **ARR submitted name** as a folder naming option.
  <img width="385" height="303" alt="image" src="https://github.com/user-attachments/assets/21a83d85-21ac-4697-95b8-1f5cccd31a30" />

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct