### PR TITLE
Mount deadlock fix

### DIFF
--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -130,8 +130,6 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// Trigger arr refresh
 	go func() {
-		// Small delay to allow any post-processing to complete before refreshing arr
-		time.Sleep(2 * time.Second)
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -130,6 +130,8 @@ func (d *Downloader) markAsCompleted(entry *storage.Entry) {
 
 	// Trigger arr refresh
 	go func() {
+		// Small delay to allow any post-processing to complete before refreshing arr
+		time.Sleep(2 * time.Second)
 		a := d.manager.arr.GetOrCreate(entry.Category)
 		a.Refresh()
 	}()

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -158,8 +158,8 @@ func (s *Service) handleBadLink(ctx context.Context, err error, entry *storage.E
 			// Entry is still bad
 			return emptyDownloadLink, fmt.Errorf("entry %s(%s) still bad after repair, un-repairable", entry.GetFolder(), dl.Link)
 		}
-		// Run the GetLink again
-		return s.GetLink(ctx, entry, dl.Filename)
+		// Bypass singleflight re-entry to avoid deadlock
+		return s.fetchAndValidate(ctx, entry, dl.Filename)
 	}
 	// Just return the error
 	return dl, err
@@ -232,8 +232,8 @@ func (s *Service) fetchLink(ctx context.Context, entry *storage.Entry, filename 
 			// Entry is still bad
 			return emptyDownloadLink, fmt.Errorf("entry %s(%s) still bad after repair, un-repairable", entry.GetFolder(), downloadLink.Link)
 		}
-		// Run the GetLink again
-		return s.GetLink(ctx, entry, filename)
+		// Bypass singleflight re-entry to avoid deadlock
+		return s.fetchAndValidate(ctx, entry, filename)
 	}
 
 	return downloadLink, nil


### PR DESCRIPTION
## 📌 Description
<!-- What does this PR do? Keep it short and clear -->
-  Fixes a goroutine self-deadlock in the link service that caused the FUSE mount to soft-lock after a torrent repair/reinsert, requiring a full restart to recover.

---

## Target Branch Check (IMPORTANT)
- [x] I confirm this PR is targeting the correct branch

**Expected target:**
- [ ] beta (for features)
- [x] main (for fixes)
 
---

## Changes Made
<!-- List key changes -->
- Replaced recursive `s.GetLink(...)` calls after repair with `s.fetchAndValidate(...)` in the link service.
- Prevented `singleflight` re-entry on the same key from inside an already in-flight call.
- Preserved existing external request deduplication behavior for concurrent callers.


---

## Testing
<!-- How was this tested? -->
- [x] Tested locally

Steps:
1. Submitted uncached torrents to RealDebrid and waited for RD-side download completion.
2. Let decypharr process symlinks and run normal post-download flow (including retries/reinsert paths).
3. Verified arr imports completed and mount no longer soft-locked over multiple days of use.

---

## Risks / Notes
<!-- Any side effects, migrations, breaking changes -->
- Low risk: change is limited to internal retry flow inside an existing `GetLink` call.
- `singleflight` deduplication for concurrent external callers remains unchanged.
- Observed “torrent not found” after old ID deletion appears to be expected post-reinsert race/noise, not a hang trigger.


---

## Screenshots (if applicable)
<!-- UI changes -->

---

## Checklist
- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct