### PR TITLE
qbit: reject auth payloads without ':' separator

### DIFF
--- a/pkg/server/qbit/context.go
+++ b/pkg/server/qbit/context.go
@@ -57,6 +57,9 @@ func decodeAuthHeader(header string) (string, string, error) {
 	bearer := string(bytes)
 
 	colonIndex := strings.LastIndex(bearer, ":")
+	if colonIndex < 0 {
+		return "", "", fmt.Errorf("invalid basic auth payload: missing ':' separator")
+	}
 	username := bearer[:colonIndex]
 	password := bearer[colonIndex+1:]
 


### PR DESCRIPTION
Closes #260. Empty/malformed Basic auth payloads triggered `bearer[:-1]` slice-bounds panic.