### PR TITLE
fix(server): match URLBase root path when URLBase != "/"

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -131,7 +132,12 @@ func New(mgr *manager.Manager) *Server {
 	routes["/webdav"] = wd.Routes()
 	routes["/sabnzbd"] = sb.Routes()
 
-	r.Route(cfg.URLBase, func(r chi.Router) {
+	// Trim trailing slash so chi registers the URLBase root path itself
+	routePath := cfg.URLBase
+	if routePath != "/" {
+		routePath = strings.TrimSuffix(routePath, "/")
+	}
+	r.Route(routePath, func(r chi.Router) {
 		// Mount web routes
 		r.Mount("/", s.WebRoutes())
 


### PR DESCRIPTION
## Description
When decypharr is hosted at a subpath like /decypharr/ behind a reverse proxy, the Dashboard tab returns 404. Every other tab loads fine, but the landing page doesn't because the router isn't matching the URLBase root itself. This change fixes the route registration so the Dashboard loads at any URLBase.


## Testing 
- Built image with DECYPHARR_URL_BASE=/decypharr/, confirmed /decypharr/ returns 200 with <title>Decypharr - Queues</title> (was 404)                         
- Confirmed /decypharr/browse, /settings, /repair, /stats, /download all still 200                                                                             
- Confirmed URLBase=/ regression-free: root + all subpaths still 200, /decypharr/ correctly 404s    