### PR TITLE
cache TorBox CDN download URLs to reduce API call frequency

### DIFF
--- a/pkg/debrid/account/account.go
+++ b/pkg/debrid/account/account.go
@@ -49,7 +49,7 @@ func (a *Account) sliceFileLink(fileLink string) string {
 func (a *Account) GetDownloadLink(id string, file *types.File, fetcher LinkFetcher) (types.DownloadLink, error) {
 	slicedLink := a.sliceFileLink(file.Link)
 	dl, ok := a.links.Load(slicedLink)
-	if !ok {
+	if !ok || (!dl.ExpiresAt.IsZero() && time.Now().After(dl.ExpiresAt)) {
 		var err error
 		dl, err = fetcher(a, id, file)
 		if err != nil {

--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -483,9 +483,22 @@ func (tb *Torbox) fetchDownloadLink(account *account.Account, id string, file *t
 	query.Set("token", account.Token)
 	query.Set("torrent_id", id)
 	query.Set("file_id", file.Id)
-	query.Set("redirect", "true")
 
 	downloadURL := fmt.Sprintf("%s/api/torrents/requestdl?%s", tb.Host, query.Encode())
+
+	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return types.DownloadLink{}, err
+	}
+	resp, err := account.Client().Do(req)
+	if err != nil {
+		return types.DownloadLink{}, err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Data string `json:"data"`
+	}
+	json.ConfigDefault.NewDecoder(resp.Body).Decode(&result)
 
 	now := time.Now()
 
@@ -495,7 +508,7 @@ func (tb *Torbox) fetchDownloadLink(account *account.Account, id string, file *t
 		Size:         file.Size,
 		Token:        tb.APIKey,
 		Link:         file.Link,
-		DownloadLink: downloadURL,
+		DownloadLink: result.Data,
 		Debrid:       tb.config.Name,
 		Id:           file.Id,
 		Generated:    now,


### PR DESCRIPTION
## 📌 Description

<!-- What does this PR do? Keep it short and clear -->
- Caches TorBox CDN links for an amount of time to avoid calling the API every time and to help avoid API limits

---

## Target Branch Check (IMPORTANT)

- [ X] I confirm this PR is targeting the correct branch

**Expected target:**

- [ ] beta (for features)

---

## Changes Made

<!-- List key changes -->
- fetchDownloadLink was building a ?redirect=true URL and storing that in the link cache. Because the redirect URL hits the TorBox API on every stream request, the cache was effectively decorative — every file access still incurred a full API round-trip and counted against rate limits.
- Removes redirect=true and instead resolves the real CDN URL at link-fetch time by decoding the JSON response. The CDN URL is then stored in the per-account link cache and reused for all stream requests until autoExpiresLinksAfter elapses.
- Also adds an expiry check in account.GetDownloadLink: ExpiresAt was already being set by all providers but was never enforced - the cache would serve stale links indefinitely until restart. The check ensures expired entries are re-fetched rather than returned.

---

## Testing

<!-- How was this tested? -->

- [X ] Tested locally

Steps:

1. build dockerfile via gitea
2. ran in place of official build
3. additional debug logging confirmed CDN cache works as expected

---

## Risks / Notes

<!-- Any side effects, migrations, breaking changes -->
- the account.GetDownloadLink: ExpiresAt is actually being enforced across all providers.

---

## Screenshots (if applicable)

<!-- UI changes -->

---

## Checklist

- [X ] Code builds successfully
- [ X] No console/log errors
- [ X] Reviewed my own code
- [ X] Target branch is correct