### PR TITLE
Fix Torbox torrent deletion endpoint/method

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -160,8 +160,8 @@ func (tb *Torbox) doPostForm(endpoint string, formData map[string]string, result
 	return resp, nil
 }
 
-// doDelete performs a DELETE request
-func (tb *Torbox) doDelete(endpoint string, payload interface{}) (*http.Response, error) {
+// doPostJSON performs a POST request with a JSON payload
+func (tb *Torbox) doPostJSON(endpoint string, payload interface{}, result interface{}) (*http.Response, error) {
 	var body io.Reader
 	if payload != nil {
 		data, err := json.Marshal(payload)
@@ -171,7 +171,7 @@ func (tb *Torbox) doDelete(endpoint string, payload interface{}) (*http.Response
 		body = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequest(http.MethodDelete, tb.Host+endpoint, body)
+	req, err := http.NewRequest(http.MethodPost, tb.Host+endpoint, body)
 	if err != nil {
 		return nil, err
 	}
@@ -182,6 +182,12 @@ func (tb *Torbox) doDelete(endpoint string, payload interface{}) (*http.Response
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if result != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 && resp.ContentLength != 0 {
+		if err := json.ConfigDefault.NewDecoder(resp.Body).Decode(result); err != nil {
+			return resp, err
+		}
+	}
 
 	return resp, nil
 }
@@ -459,9 +465,18 @@ func (tb *Torbox) CheckStatus(torrent *types.Torrent) (*types.Torrent, error) {
 }
 
 func (tb *Torbox) DeleteTorrent(torrentId string) error {
-	payload := map[string]string{"torrent_id": torrentId, "action": "Delete"}
+	id, err := strconv.Atoi(torrentId)
+	if err != nil {
+		return fmt.Errorf("invalid torrent id: %s", torrentId)
+	}
 
-	resp, err := tb.doDelete(fmt.Sprintf("/api/torrents/controltorrent/%s", torrentId), payload)
+	payload := map[string]interface{}{
+		"torrent_id": id,
+		"operation":  "delete",
+		"all":        false,
+	}
+
+	resp, err := tb.doPostJSON("/api/torrents/controltorrent", payload, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 📌 Description

<!-- What does this PR do? Keep it short and clear -->
- Fix Torbox delete by using the correct control endpoint and payload per the Torbox API spec: https://api-docs.torbox.app/
- Closes #295

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

<!-- List key changes -->
- Add JSON POST helper for Torbox requests.
- Update Torbox delete to POST `/api/torrents/controltorrent` with `torrent_id`, `operation`, and `all`.
- Validate `torrent_id` is numeric before sending.

---

## Testing

<!-- How was this tested? -->

- [x] Tested locally

Steps:

1. Manual Torbox API call ({"success":true,"error":null,"detail":"Torrent deleted successfully.","data":null}):

   ```bash
   curl --location 'https://api.torbox.app/v1/api/torrents/controltorrent' \
     --header 'Authorization: Bearer [REDACTED]' \
     --header 'Content-Type: application/json' \
     --data '{"torrent_id":[REDACTED],"operation":"delete","all":false}'
   ```

2. Deployed locally in a container and verified deletion in Torbox dashboard.
3. Confirmed log line: "Torrent [REDACTED] deleted from Torbox".

---

## Risks / Notes

<!-- Any side effects, migrations, breaking changes -->
- No known risks; request shape matches the Torbox API spec.
- If Torbox’s Go SDK stays actively maintained, consider migrating the pkg/debrid/providers/torbox HTTP layer to it to reduce API drift and simplify request/response handling.

---

## Screenshots (if applicable)

<!-- UI changes -->

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct
