### PR TITLE
fix dfs downloader teardown race

### DIFF
--- a/pkg/mount/dfs/vfs/downloaders.go
+++ b/pkg/mount/dfs/vfs/downloaders.go
@@ -84,11 +84,9 @@ type Downloaders struct {
 	circuitOpenAt atomic.Int64 // Unix nano timestamp when circuit opened
 }
 
-// ensureStreamTracked makes sure the active stream is registered when reads begin.
-func (dls *Downloaders) ensureStreamTracked() {
-	dls.mu.Lock()
-	defer dls.mu.Unlock()
-
+// ensureStreamTrackedLocked makes sure the active stream is registered when
+// reads begin. Caller must hold dls.mu.
+func (dls *Downloaders) ensureStreamTrackedLocked() {
 	if dls.closed || dls.streamID != "" {
 		return
 	}
@@ -242,8 +240,6 @@ func (dls *Downloaders) Download(ctx context.Context, r ranges.Range) error {
 		return fmt.Errorf("circuit breaker open, cooldown active: last error: %w", lastErr)
 	}
 
-	dls.ensureStreamTracked()
-
 	// Update activity timestamp for idle detection
 	dls.touchActivity()
 
@@ -251,6 +247,15 @@ func (dls *Downloaders) Download(ctx context.Context, r ranges.Range) error {
 	if dls.closed {
 		dls.mu.Unlock()
 		return errors.New("downloaders closed")
+	}
+	if dls.stopping {
+		dls.mu.Unlock()
+		return errors.New("downloaders stopping")
+	}
+	if dls.ctx.Err() != nil {
+		err := dls.ctx.Err()
+		dls.mu.Unlock()
+		return err
 	}
 
 	// Lazy restart: if we went idle, restart the kicker goroutine. Skipped
@@ -260,6 +265,7 @@ func (dls *Downloaders) Download(ctx context.Context, r ranges.Range) error {
 		dls.idle = false
 		dls.ensureKickerRunningLocked()
 	}
+	dls.ensureStreamTrackedLocked()
 
 	// Fast path: already have it
 	if dls.item.HasRange(r) {

--- a/pkg/mount/dfs/vfs/downloaders_test.go
+++ b/pkg/mount/dfs/vfs/downloaders_test.go
@@ -186,6 +186,36 @@ func TestStopAllClearsWaiters(t *testing.T) {
 	}
 }
 
+func TestDownloadDoesNotCreateWorkWhileStopping(t *testing.T) {
+	parentCtx := context.Background()
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	dls := &Downloaders{
+		parentCtx: parentCtx,
+		ctx:       ctx,
+		cancel:    cancel,
+		stopping:  true,
+		item: &CacheItem{
+			info: ItemInfo{Size: 1 * testMiB},
+		},
+	}
+
+	err := dls.Download(context.Background(), ranges.Range{Pos: 0, Size: 1})
+	if err == nil {
+		t.Fatal("expected Download to fail while StopAll is active")
+	}
+	if got := len(dls.waiters); got != 0 {
+		t.Fatalf("Download created waiters while stopping: got %d, want 0", got)
+	}
+	if got := len(dls.dls); got != 0 {
+		t.Fatalf("Download created downloaders while stopping: got %d, want 0", got)
+	}
+	if dls.streamID != "" {
+		t.Fatal("Download registered a stream while stopping")
+	}
+}
+
 func TestCacheItemReleaseStopsDownloadersOnZeroOpens(t *testing.T) {
 	parentCtx := context.Background()
 	ctx, cancel := context.WithCancel(parentCtx)


### PR DESCRIPTION
## Summary

Fixes a DFS downloader teardown race that can allow late FUSE reads to create new stream work while `StopAll()` is actively shutting down the current downloader session.

## Changes

- Renamed `ensureStreamTracked()` to `ensureStreamTrackedLocked()` to make the locking contract explicit.
- Moved stream tracking inside the existing `Download()` critical section.
- Added guards in `Download()` to reject work when:
  - the downloader is closed
  - `StopAll()` is currently running
  - the downloader context has already been canceled
- Added a regression test proving `Download()` does not create waiters, downloaders, or stream registrations while teardown is active.

## Reason

When a client disconnects abruptly, such as Tunarr killing ffmpeg after playback stops, FUSE can still issue late reads while the last file handle is being released.

Previously, `Download()` could race with `StopAll()` and create new downloader state during teardown. That could leave Decypharr spinning after playback ended, matching observed high CPU with no active media
reads.

The fix makes teardown a hard boundary: once `StopAll()` begins, new read work is rejected until the next clean session starts.

## Verification

- Built the Decypharr builder image successfully.
- Ran:

```bash
go test ./pkg/mount/dfs/...
```

- DFS tests passed, including the new regression test.