### PR TITLE
feat: auto-prune terminal repair failures + refresh optimization

### DIFF
--- a/pkg/manager/fixer.go
+++ b/pkg/manager/fixer.go
@@ -106,6 +106,21 @@ func (f *Fixer) FixTorrent(ctx context.Context, entry *storage.Entry, skipCurren
 
 	var lastErr error
 	totalAttempts := 0
+	refreshNeeded := false
+	skipPersist := false
+	persistState := func() {
+		if skipPersist {
+			return
+		}
+		callback := func(t *storage.Entry) {
+			f.manager.RefreshEntries(true)
+		}
+		if !refreshNeeded {
+			callback = nil
+		}
+		_ = f.manager.AddOrUpdate(entry, callback)
+	}
+	defer persistState()
 
 	for _, debridName := range attemptOrder {
 		// Check if entry has been marked as failed to re-insert
@@ -152,6 +167,7 @@ func (f *Fixer) FixTorrent(ctx context.Context, entry *storage.Entry, skipCurren
 				Error:         nil,
 				AttemptsCount: totalAttempts,
 			}
+			refreshNeeded = true
 			req.result <- result
 			return result, nil
 		}
@@ -173,9 +189,14 @@ func (f *Fixer) FixTorrent(ctx context.Context, entry *storage.Entry, skipCurren
 	// Mark entry as bad
 	entry.Bad = true
 	entry.UpdatedAt = time.Now()
-	_ = f.manager.AddOrUpdate(entry, func(t *storage.Entry) {
-		f.manager.RefreshEntries(true)
-	})
+	refreshNeeded = true
+
+	if err := f.manager.DeleteEntry(entry.InfoHash, true); err != nil {
+		f.manager.logger.Warn().Err(err).Str("infohash", entry.InfoHash).Msg("Failed to auto-prune terminal bad entry")
+	} else {
+		skipPersist = true
+		f.manager.logger.Info().Str("infohash", entry.InfoHash).Msg("Auto-pruned terminal bad entry")
+	}
 
 	result := &FixResult{
 		Success:       false,
@@ -195,11 +216,6 @@ func (f *Fixer) MoveTorrent(entry *storage.Entry, debridName string, reinsert bo
 	if !entry.CanBeMoved() {
 		return false, fmt.Errorf("entry %s cannot be moved", entry.Name)
 	}
-
-	defer func() {
-		// Save to storage
-		_ = f.manager.AddOrUpdate(entry, nil) // No need to refresh mounts
-	}()
 
 	client := f.manager.ProviderClient(debridName)
 	if client == nil {


### PR DESCRIPTION
When all repair attempts are exhausted:
- Auto-delete the dead entry from storage instead of just marking Bad
- Track refreshNeeded to only refresh entries when actual changes occur
- Remove unnecessary defer AddOrUpdate from MoveTorrent

This prevents zombie entries from lingering indefinitely and ensures Radarr/Sonarr can retry downloads cleanly.

Closes #146

## 📌 Description

<!-- What does this PR do? Keep it short and clear -->
- 

---

## Target Branch Check (IMPORTANT)

- [ ] I confirm this PR is targeting the correct branch

**Expected target:**

- [ ] beta (for features)

---

## Changes Made

<!-- List key changes -->
- 

-
-

---

## Testing

<!-- How was this tested? -->

- [ ] Tested locally

Steps:

1.
2.
3.

---

## Risks / Notes

<!-- Any side effects, migrations, breaking changes -->
- 

---

## Screenshots (if applicable)

<!-- UI changes -->

---

## Checklist

- [ ] Code builds successfully
- [ ] No console/log errors
- [ ] Reviewed my own code
- [ ] Target branch is correct