### PR TITLE
fix(torbox): resolve CDN URL once to eliminate per-chunk 429s and prevent 502 mount poisoning

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -479,29 +479,44 @@ func (tb *Torbox) GetDownloadLink(id string, file *types.File) (types.DownloadLi
 }
 
 func (tb *Torbox) fetchDownloadLink(account *account.Account, id string, file *types.File) (types.DownloadLink, error) {
-	query := url.Values{}
-	query.Set("token", account.Token)
-	query.Set("torrent_id", id)
-	query.Set("file_id", file.Id)
-	query.Set("redirect", "true")
+	var res DownloadLinksResponse
 
-	downloadURL := fmt.Sprintf("%s/api/torrents/requestdl?%s", tb.Host, query.Encode())
+	resp, err := tb.doGet("/api/torrents/requestdl", map[string]string{
+		"token":      account.Token,
+		"torrent_id": id,
+		"file_id":    file.Id,
+	}, &res)
+	if err != nil {
+		return types.DownloadLink{}, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return types.DownloadLink{}, fmt.Errorf("torbox requestdl error: HTTP %d", resp.StatusCode)
+	}
+	if !res.Success || res.Data == nil || *res.Data == "" {
+		return types.DownloadLink{}, fmt.Errorf("torbox: empty CDN URL from requestdl: %s", res.Detail)
+	}
+
+	// TorBox CDN URLs are valid for 3 hours. Never cache them longer than that
+	// regardless of the user's auto_expire_links_after setting, otherwise we
+	// serve stale URLs that return 403/404 from the CDN.
+	const torboxCDNExpiry = 3 * time.Hour
+	expiry := torboxCDNExpiry
+	if tb.autoExpiresLinksAfter > 0 && tb.autoExpiresLinksAfter < torboxCDNExpiry {
+		expiry = tb.autoExpiresLinksAfter
+	}
 
 	now := time.Now()
-
-	// Always expires
-	dl := types.DownloadLink{
+	return types.DownloadLink{
 		Filename:     file.Name,
 		Size:         file.Size,
 		Token:        tb.APIKey,
 		Link:         file.Link,
-		DownloadLink: downloadURL,
+		DownloadLink: *res.Data,
 		Debrid:       tb.config.Name,
 		Id:           file.Id,
 		Generated:    now,
-		ExpiresAt:    now.Add(tb.autoExpiresLinksAfter),
-	}
-	return dl, nil
+		ExpiresAt:    now.Add(expiry),
+	}, nil
 }
 
 func (tb *Torbox) GetTorrents() ([]*types.Torrent, error) {

--- a/pkg/manager/link/errors.go
+++ b/pkg/manager/link/errors.go
@@ -94,7 +94,9 @@ var (
 var (
 	Err404 = errors.New("HTTP 404 Not Found")
 	Err429 = errors.New("HTTP 429 Too Many Requests")
+	Err502 = errors.New("HTTP 502 Bad Gateway")
 	Err503 = errors.New("HTTP 503 Service Unavailable")
+	Err504 = errors.New("HTTP 504 Gateway Timeout")
 )
 
 // NewLinkError creates a new LinkError with the given error and category
@@ -145,8 +147,12 @@ func ErrorCodeToLinkError(code string) *Error {
 		return NewPermanentError(Err404, code)
 	case "429":
 		return NewRetryableError(Err429, code)
+	case "502":
+		return NewRetryableError(Err502, code)
 	case "503":
 		return NewRetryableError(Err503, code)
+	case "504":
+		return NewRetryableError(Err504, code)
 	default:
 		return NewPermanentError(fmt.Errorf("unknown error code: %s", code), code)
 	}

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog"
@@ -107,6 +108,13 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 	// Check if we've already validated this link
 	if validationErr, exists := s.validated.Load(link.DownloadLink); exists {
 		if validationErr == nil {
+			// Re-fetch if the cached CDN URL has passed its declared expiry.
+			// Without this check a 3-hour TorBox CDN URL would be served from
+			// s.validated forever — bypassing the HEAD validation that would
+			// otherwise catch the expired URL.
+			if !link.ExpiresAt.IsZero() && time.Now().After(link.ExpiresAt) {
+				return s.invalidateAndRefetch(ctx, entry, link, attempt)
+			}
 			return link, nil // Already validated successfully
 		}
 		// Previous validation failed - check if we should retry

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -145,8 +145,13 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 		}
 	}
 
-	// Store validation result
-	s.validated.Store(link.DownloadLink, validationErr)
+	// Only cache permanent/refetchable failures and successes.
+	// Retryable errors (502, 503, 429) must not be cached: a single transient
+	// failure would block all future reads for the file until the cache is
+	// explicitly cleared (account-disable or restart).
+	if linkErr := GetLinkError(validationErr); linkErr == nil || !linkErr.ShouldRetry() {
+		s.validated.Store(link.DownloadLink, validationErr)
+	}
 
 	if validationErr == nil {
 		return link, nil

--- a/pkg/manager/stream.go
+++ b/pkg/manager/stream.go
@@ -368,6 +368,16 @@ func (m *Manager) doRequest(ctx context.Context, url string, start, end int64) (
 				}
 				return retry.Unrecoverable(StreamError{Err: doErr, Retryable: true})
 			}
+
+			// A 5xx from the CDN is a transient upstream failure, not a
+			// connection error, so doErr is nil and the retry loop would exit
+			// without retrying. Treat it as retryable here so retry.Do fires.
+			if resp.StatusCode >= 500 {
+				status := resp.StatusCode
+				resp.Body.Close()
+				resp = nil
+				return fmt.Errorf("CDN returned HTTP %d", status)
+			}
 			return nil
 		},
 		retry.Context(ctx),


### PR DESCRIPTION
## Problem

Two related issues with TorBox CDN links:

1. Per-chunk 429 rate-limiting: decypharr called the TorBox requestdl API for every chunk of every file. On large files this produces hundreds of API calls, hitting rate limits and causing 429 errors that stall downloads.

2. 502 CDN errors permanently poisoning the FUSE mount: a transient 502 was cached and returned forever, making files unreadable until decypharr restarted.

## Fix

**44d48c6 - Prevent CDN 502 errors from permanently poisoning the FUSE mount**
- Cache eviction on 502 so the next read re-resolves the CDN link

**a64ef97 - Resolve actual CDN URL from requestdl once, reuse for all chunks**
- Direct CDN URL is resolved once per file and stored; all chunk reads use it directly
- Eliminates the N*chunks API calls that caused 429 rate limiting

## Impact

A 10 GB file downloaded in 8 MB chunks previously made ~1,250 API calls. This fix reduces that to 1 call per file.