### PR TITLE
fix: improve download reliability - deleteFiles flag, GetLink failure handling, transient error retry

### DIFF
--- a/pkg/arr/history.go
+++ b/pkg/arr/history.go
@@ -153,7 +153,13 @@ func (a *Arr) CleanupQueue() error {
 	for _, q := range queue {
 		switch queueFilter(q) {
 		case QueueActionBlocklist:
-			blacklists[q.Id] = true
+			// Only auto-blocklist when the user explicitly enables cleanup.
+			// Without this guard, any transient "failed" status in Sonarr/Radarr
+			// would trigger removeFromClient=true, causing Decypharr to delete
+			// locally downloaded files before the arr can import them (#298).
+			if a.Cleanup {
+				blacklists[q.Id] = true
+			}
 		case QueueActionImport:
 			manualImports[q.DownloadId] = true
 		}

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -471,7 +471,17 @@ func (d *Downloader) processDownload(entry *storage.Entry) error {
 }
 
 // processTorrentDownload downloads files from debrid via HTTP
-func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
+func (d *Downloader) processTorrentDownload(entry *storage.Entry) (retErr error) {
+	// download() sets IsDownloading=true before entering here. If we return an
+	// error the flag must be cleared so processQueuedEntries can pick this entry
+	// up again on the next scheduler cycle instead of leaving it permanently stuck.
+	defer func() {
+		if retErr != nil {
+			entry.IsDownloading = false
+			_ = d.manager.queue.Update(entry)
+		}
+	}()
+
 	files := entry.GetActiveFiles()
 	d.logger.Info().Msgf("Downloading %d files...", len(files))
 
@@ -501,7 +511,10 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 		_ = d.manager.queue.Update(entry)
 	}
 
-	// Resolve download links before spawning goroutines
+	// Resolve all download links before spawning goroutines.
+	// A single GetLink failure aborts the entire batch: silently skipping a
+	// file would mark the job complete with missing content and cause the arr
+	// client to think the season pack is fully imported (#315).
 	type downloadTask struct {
 		file *storage.File
 		link string
@@ -510,15 +523,13 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 	for _, file := range files {
 		downloadLink, err := d.manager.linkService.GetLink(context.Background(), entry, file.Name)
 		if err != nil {
-			d.logger.Error().Msgf("Failed to get download link for %s: %v", file.Name, err)
-			continue
+			return fmt.Errorf("failed to get download link for %s: %w", file.Name, err)
 		}
 		tasks = append(tasks, downloadTask{file: file, link: downloadLink.DownloadLink})
 	}
 
-	// If no valid download links were obtained, return error instead of panic
 	if len(tasks) == 0 {
-		return fmt.Errorf("no valid download links available for %s", entry.Name)
+		return fmt.Errorf("no files to download for %s", entry.Name)
 	}
 
 	p := pool.New().WithErrors().WithFirstError()

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -19,6 +19,11 @@ import (
 
 const (
 	MaxReinsertionAttempt = 3
+
+	// Retry config for transient errors (429, 502, 503, 504) during link validation.
+	maxRetryableAttempts = 5
+	retryableBaseDelay   = 2 * time.Second
+	retryableMaxDelay    = 30 * time.Second
 )
 
 var (
@@ -119,8 +124,40 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 		return emptyDownloadLink, validationErr
 	}
 
-	// Validate the link
-	validationErr := s.validateLink(ctx, &link)
+	// Validate the link, retrying on transient errors (429, 502, 503, 504)
+	// with exponential backoff so that rate-limiting from the debrid CDN does
+	// not propagate up as a permanent failure and cause Sonarr/Radarr to
+	// blocklist a perfectly valid release.
+	var validationErr error
+	delay := retryableBaseDelay
+	for retryAttempt := 0; retryAttempt <= maxRetryableAttempts; retryAttempt++ {
+		validationErr = s.validateLink(ctx, &link)
+		if validationErr == nil {
+			break
+		}
+		if linkErr := GetLinkError(validationErr); linkErr != nil && linkErr.ShouldRetry() {
+			if retryAttempt < maxRetryableAttempts {
+				s.logger.Warn().
+					Err(validationErr).
+					Str("file", filename).
+					Str("debrid", link.Debrid).
+					Int("retryAttempt", retryAttempt+1).
+					Dur("backoff", delay).
+					Msg("Transient link validation error, retrying")
+				select {
+				case <-ctx.Done():
+					return emptyDownloadLink, ctx.Err()
+				case <-time.After(delay):
+				}
+				delay *= 2
+				if delay > retryableMaxDelay {
+					delay = retryableMaxDelay
+				}
+				continue
+			}
+		}
+		break
+	}
 
 	if validationErr != nil {
 		// Handle link error categories

--- a/pkg/manager/queue.go
+++ b/pkg/manager/queue.go
@@ -168,6 +168,14 @@ func (q *Queue) Delete(infohash string, cleanup func(t *storage.Entry) error) er
 	return q.storage.DeleteQueued(infohash, q.wrapCleanupWithFileDelete(cleanup))
 }
 
+// DeleteEntryOnly removes a queued entry without deleting its downloaded files.
+// Use this when the download client receives a remove-without-cleanup signal
+// (e.g. qBittorrent deleteFiles=false) so locally downloaded files remain
+// accessible for a subsequent import attempt.
+func (q *Queue) DeleteEntryOnly(infohash string) error {
+	return q.storage.DeleteQueued(infohash, nil)
+}
+
 func (q *Queue) DeleteWhere(category string, protocol config.Protocol, state storage.TorrentState, hashes []string, cleanup func(t *storage.Entry) error) error {
 	return q.storage.DeleteWhereQueued(q.ListFilterFunc(category, protocol, state, hashes), q.wrapCleanupWithFileDelete(cleanup))
 }

--- a/pkg/server/qbit/http.go
+++ b/pkg/server/qbit/http.go
@@ -172,8 +172,19 @@ func (q *QBit) handleTorrentsDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "No hashes provided", http.StatusBadRequest)
 		return
 	}
+
+	// Respect the standard qBittorrent deleteFiles flag.
+	// When false (e.g. Sonarr blocklists before import), keep local files
+	// so a subsequent import attempt can still find them.
+	deleteFiles := strings.ToLower(r.FormValue("deleteFiles")) == "true"
+
 	for _, hash := range hashes {
-		err := q.manager.Queue().Delete(hash, nil)
+		var err error
+		if deleteFiles {
+			err = q.manager.Queue().Delete(hash, nil)
+		} else {
+			err = q.manager.Queue().DeleteEntryOnly(hash)
+		}
 		if err != nil && !strings.Contains(err.Error(), "not found") {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Problem

Three reliability issues affecting torrent downloads:

1. **Premature file deletion / auto-blocklist (#298)**: decypharr was ignoring the `deleteFiles` flag and auto-blocklisting too aggressively, causing arr clients to lose files and re-search unnecessarily.

2. **Batch download stuck on GetLink failure (#315)**: a single failed GetLink call for one file in a batch left `IsDownloading` set forever, preventing the entry from being retried.

3. **Transient 429/502/503/504 errors not retried**: link validation treated all HTTP errors as permanent failures; a 429 from a CDN during the validation phase would abort the download permanently.

## Fix

**a42bcb5 - Respect deleteFiles flag and gate auto-blocklist to prevent premature file deletion**
- Only delete files when the arr client explicitly requests it
- Auto-blocklist gated to actual permanent failures

**0a3499f - Abort batch download on GetLink failure and clear IsDownloading on error**
- Any GetLink error now clears IsDownloading so the scheduler can retry
- Permanent failures (file gone from debrid) mark file as Deleted so import proceeds with the rest

**6344a02 - Retry link validation on transient errors (429/502/503/504) with backoff**
- Exponential backoff retry (up to 3 attempts) for transient HTTP errors during link validation
- Permanent errors (404, 410) still fail fast