### PR TITLE
fix: handle missing Usenet articles and prevent NZB ffprobe D-state deadlock

### DIFF
--- a/internal/customerror/error.go
+++ b/internal/customerror/error.go
@@ -46,6 +46,13 @@ func (e *Error) IsPermanent() bool {
 	return e.permanent
 }
 
+func (e *Error) StatusCode() int {
+	if e.statusCode == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.statusCode
+}
+
 func (e *Error) IsSilent() bool {
 	if e.err == nil {
 		return false
@@ -132,6 +139,7 @@ func NewArticleNotFoundError(err error) *Error {
 		err = errors.New("article not found")
 	}
 	return (&Error{
-		err: err,
+		err:        err,
+		statusCode: http.StatusGone,
 	}).Permanent()
 }

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/internal/config"
 	"github.com/sirrobot01/decypharr/internal/nntp"
+	"github.com/sirrobot01/decypharr/pkg/manager/link"
 	"github.com/sirrobot01/decypharr/pkg/notifications"
 	"github.com/sirrobot01/decypharr/pkg/storage"
 	"github.com/sourcegraph/conc/pool"
@@ -208,8 +209,12 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		return err
 	}
 
-	// Run ffprobe on files to warm cache and trigger imports
-	if !d.manager.config.SkipPreCache && len(filePaths) > 0 {
+	// Run ffprobe on files to warm cache and trigger imports.
+	// Skip for NZB entries: their FUSE files are served on-demand from NNTP,
+	// so ffprobe blocks on a D-state kernel read and cmd.Wait() never returns,
+	// preventing completeEntry from being called. PreCache in usenet.go handles
+	// cache warming for NZB via head/tail segment pre-fetch instead.
+	if !d.manager.config.SkipPreCache && len(filePaths) > 0 && !entry.IsNZB() {
 		probeFiles := filePaths
 		if len(probeFiles) > MaxNZBPreCacheFiles {
 			probeFiles = probeFiles[:MaxNZBPreCacheFiles]
@@ -502,24 +507,38 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 		_ = d.manager.queue.Update(entry)
 	}
 
-	// Resolve download links before spawning goroutines
+	// Resolve all download links before spawning goroutines.
+	// Transient GetLink failures abort the entire batch so the scheduler retries.
+	// Permanent failures (file gone from debrid) mark the file Deleted so the
+	// arr client imports whatever did resolve and re-searches for the rest.
 	type downloadTask struct {
 		file *storage.File
 		link string
 	}
 	var tasks []downloadTask
+	permanentFailures := 0
 	for _, file := range files {
 		downloadLink, err := d.manager.linkService.GetLink(context.Background(), entry, file.Name)
 		if err != nil {
-			d.logger.Error().Msgf("Failed to get download link for %s: %v", file.Name, err)
-			continue
+			if linkErr := link.GetLinkError(err); linkErr != nil && linkErr.IsPermanent() {
+				file.Deleted = true
+				permanentFailures++
+				d.logger.Warn().Msgf("File permanently unavailable on debrid, marking deleted: %s", file.Name)
+				continue
+			}
+			return fmt.Errorf("failed to get download link for %s: %w", file.Name, err)
 		}
 		tasks = append(tasks, downloadTask{file: file, link: downloadLink.DownloadLink})
 	}
 
 	// If no valid download links were obtained, return error instead of panic
 	if len(tasks) == 0 {
-		return fmt.Errorf("no valid download links available for %s", entry.Name)
+		return fmt.Errorf("no files available for download for %s", entry.Name)
+	}
+
+	if permanentFailures > 0 {
+		d.logger.Info().Msgf("Partial download: %d/%d files available for %s", len(tasks), len(files), entry.Name)
+		_ = d.manager.queue.Update(entry)
 	}
 
 	p := pool.New().WithErrors().WithFirstError()

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -16,6 +16,7 @@ import (
 	grab "github.com/cavaliergopher/grab/v3"
 	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/nntp"
 	"github.com/sirrobot01/decypharr/pkg/notifications"
 	"github.com/sirrobot01/decypharr/pkg/storage"
 	"github.com/sourcegraph/conc/pool"
@@ -550,7 +551,17 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 }
 
 // processUsenetDownload downloads NZB files via parallel NNTP segment fetching
-func (d *Downloader) processUsenetDownload(entry *storage.Entry) error {
+func (d *Downloader) processUsenetDownload(entry *storage.Entry) (retErr error) {
+	// download() sets IsDownloading=true before entering here. Reset it on any
+	// error path so the scheduler can pick the entry up again on the next cycle
+	// instead of leaving it permanently stuck with IsDownloading=true.
+	defer func() {
+		if retErr != nil {
+			entry.IsDownloading = false
+			_ = d.manager.queue.Update(entry)
+		}
+	}()
+
 	if d.manager.usenet == nil {
 		return fmt.Errorf("usenet client not configured")
 	}
@@ -577,16 +588,25 @@ func (d *Downloader) processUsenetDownload(entry *storage.Entry) error {
 	// Track per-file progress so we can compute the global total across all files
 	fileProgress := make(map[string]int64)
 
-	p := pool.New().WithErrors().WithFirstError()
+	// fileErrs[i] is written only by goroutine i — no lock needed.
+	type fileErr struct {
+		permanent bool // true = 430 article-not-found; false = transient error
+		err       error
+	}
+	fileErrs := make([]fileErr, len(files))
+
+	p := pool.New()
 	if d.maxDownloads > 0 {
 		p = p.WithMaxGoroutines(d.maxDownloads)
 	}
-	for _, file := range files {
-		p.Go(func() error {
+	for i, file := range files {
+		i, file := i, file
+		p.Go(func() {
 			destPath := filepath.Join(downloadedFolder, file.Name)
 			destFile, err := os.Create(destPath)
 			if err != nil {
-				return fmt.Errorf("failed to create file %s: %w", file.Name, err)
+				fileErrs[i] = fileErr{err: fmt.Errorf("failed to create file %s: %w", file.Name, err)}
+				return
 			}
 			defer destFile.Close()
 
@@ -607,25 +627,67 @@ func (d *Downloader) processUsenetDownload(entry *storage.Entry) error {
 
 			if err := d.manager.usenet.Download(d.manager.ctx, entry.InfoHash, file.Name, destFile, progressCallback); err != nil {
 				_ = os.Remove(destPath)
-				return fmt.Errorf("failed to download %s: %w", file.Name, err)
+				fileErrs[i] = fileErr{
+					// 430 article-not-found is a permanent failure — the content
+					// is gone from all providers and retrying will not help.
+					permanent: nntp.IsArticleNotFoundError(err),
+					err:       fmt.Errorf("failed to download %s: %w", file.Name, err),
+				}
+				return
 			}
-
 			d.logger.Info().Msgf("Downloaded NZB file: %s", file.Name)
-			return nil
 		})
 	}
+	p.Wait()
 
-	err := p.Wait()
-
-	if err != nil {
-		entry.MarkAsError(err)
-		_ = d.manager.queue.Update(entry)
-		return fmt.Errorf("NZB download failed: %w", err)
+	// Tally outcomes and decide how to proceed.
+	var permanentCount, transientCount int
+	for i, fe := range fileErrs {
+		if fe.err == nil {
+			continue
+		}
+		if fe.permanent {
+			permanentCount++
+			// Mark the file as deleted so GetActiveFiles skips it on subsequent
+			// calls. The arr client will import the files that did download and
+			// re-search for the missing ones automatically.
+			files[i].Deleted = true
+			d.logger.Warn().Msgf("File permanently unavailable on Usenet, marking deleted: %s", files[i].Name)
+		} else {
+			transientCount++
+			d.logger.Error().Err(fe.err).Msgf("Transient error downloading NZB file")
+		}
 	}
 
-	d.completeEntry(entry)
-	d.logger.Info().Msgf("Downloaded all NZB files for %s", entry.Name)
-	return nil
+	successCount := len(files) - permanentCount - transientCount
+
+	switch {
+	case transientCount > 0:
+		// Network / timeout failures — clean up and let the scheduler retry.
+		_ = os.RemoveAll(downloadedFolder)
+		return fmt.Errorf("%d NZB file(s) failed with transient errors", transientCount)
+
+	case permanentCount > 0 && successCount == 0:
+		// Every file is permanently gone — clean up and mark error so the arr
+		// client can blocklist the release and trigger a fresh search.
+		_ = os.RemoveAll(downloadedFolder)
+		entry.MarkAsError(fmt.Errorf("all %d file(s) unavailable on Usenet", permanentCount))
+		_ = d.manager.queue.Update(entry)
+		return fmt.Errorf("NZB download failed: all files unavailable on Usenet")
+
+	case permanentCount > 0:
+		// Some files permanently missing but others downloaded successfully.
+		// Complete the entry with the available files; the arr client imports
+		// what is there and re-searches for the episodes/parts that are missing.
+		d.logger.Info().Msgf("Partial NZB download: %d/%d files available for %s", successCount, len(files), entry.Name)
+		d.completeEntry(entry)
+		return nil
+
+	default:
+		d.completeEntry(entry)
+		d.logger.Info().Msgf("Downloaded all NZB files for %s", entry.Name)
+		return nil
+	}
 }
 
 // processStrm creates symlinks for torrent files

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -583,6 +583,14 @@ func (m *Manager) DeleteEntry(infohash string, removePlacements bool) error {
 	if err := m.storage.Delete(infohash); err != nil {
 		return err
 	}
+
+	// Clean up NZB metadata so WebDAV stops serving the file path after deletion
+	if torr.Protocol == config.ProtocolNZB && m.usenet != nil {
+		if err := m.usenet.Delete(infohash); err != nil {
+			m.logger.Warn().Err(err).Str("infohash", infohash).Msg("Failed to delete NZB metadata after queue entry deletion")
+		}
+	}
+
 	// Refresh entry cache
 	m.RefreshEntries(true)
 	return nil

--- a/pkg/manager/mount.go
+++ b/pkg/manager/mount.go
@@ -77,6 +77,8 @@ func (m *Manager) RunFFprobe(filePaths []string) error {
 			defer cancel()
 			cmd := exec.CommandContext(ctx, "ffprobe",
 				"-v", "quiet",
+				"-probesize", "50M",
+				"-analyzeduration", "0",
 				"-print_format", "json",
 				"-show_format",
 				"-show_streams",

--- a/pkg/manager/stream.go
+++ b/pkg/manager/stream.go
@@ -292,6 +292,13 @@ func (m *Manager) streamUsenet(ctx context.Context, entry *storage.Entry, filena
 		return retry.Unrecoverable(fmt.Errorf("file not found in entry: %s", filename))
 	}
 
+	// Check for permanent article-not-found failures BEFORE writing HTTP response headers.
+	// This lets the caller return a non-retryable status (410 Gone) instead of starting a
+	// response that the client will retry after the connection drops.
+	if err := m.usenet.IsFilePermanentlyFailed(entry.InfoHash, filename); err != nil {
+		return err
+	}
+
 	contentLength := end - start + 1
 
 	// Only build headers if onReady callback is provided (avoids allocations for DFS streaming)

--- a/pkg/server/webdav/actions.go
+++ b/pkg/server/webdav/actions.go
@@ -106,7 +106,7 @@ func (h *Handler) handleDownload(info *manager.FileInfo, w http.ResponseWriter, 
 		var streamErr *customerror.Error
 		if errors.As(err, &streamErr) {
 			if !streamErr.HeadersWritten {
-				http.Error(w, streamErr.Error(), http.StatusInternalServerError)
+				http.Error(w, streamErr.Error(), streamErr.StatusCode())
 			}
 			if !streamErr.IsSilent() {
 				h.logger.Rate(logKey).Error().Err(err).Msgf("Error streaming file: %s", logKey)

--- a/pkg/usenet/usenet.go
+++ b/pkg/usenet/usenet.go
@@ -544,15 +544,68 @@ func (u *Usenet) Close() error {
 }
 
 func (u *Usenet) getFile(nzoID, filename string) (*storage.NZBFile, error) {
-	files, err := u.getFiles(nzoID, []string{filename})
+	nzb, err := u.nzbStorage.GetNZB(nzoID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("metadata load failed: %w", err)
 	}
-	file := files[filename]
-	if file == nil {
-		return nil, fmt.Errorf("file %s not found in NZB %s", filename, nzoID)
+	for i := range nzb.Files {
+		source := nzb.Files[i]
+		if source.Name != filename {
+			continue
+		}
+		if source.IsDeleted {
+			return nil, customerror.NewArticleNotFoundError(
+				fmt.Errorf("file %s is permanently unavailable on Usenet", filename),
+			)
+		}
+		file := source
+		if file.NzbID == "" {
+			file.NzbID = nzoID
+		}
+		return &file, nil
 	}
-	return file, nil
+	return nil, fmt.Errorf("file %s not found in NZB %s", filename, nzoID)
+}
+
+// markNZBFileDeleted marks a specific NZB file as permanently deleted in storage so the
+// article-not-found status survives process restarts.
+func (u *Usenet) markNZBFileDeleted(nzoID, filename string) {
+	nzb, err := u.nzbStorage.GetNZB(nzoID)
+	if err != nil {
+		u.logger.Warn().Err(err).Str("nzo_id", nzoID).Str("file", filename).Msg("Failed to load NZB to mark file as deleted")
+		return
+	}
+	for i := range nzb.Files {
+		if nzb.Files[i].Name == filename {
+			nzb.Files[i].IsDeleted = true
+			if err := u.nzbStorage.AddNZB(nzb); err != nil {
+				u.logger.Warn().Err(err).Str("nzo_id", nzoID).Str("file", filename).Msg("Failed to persist deleted file status")
+			}
+			return
+		}
+	}
+}
+
+// IsFilePermanentlyFailed returns a non-nil error if the file is known to be permanently
+// unavailable on Usenet, allowing callers to short-circuit before writing HTTP response headers.
+func (u *Usenet) IsFilePermanentlyFailed(nzoID, filename string) error {
+	key := fsKey(nzoID, filename)
+	if cause, ok := u.failedFiles.Load(key); ok {
+		return customerror.NewArticleNotFoundError(cause)
+	}
+	// Check persistent storage so the status survives restarts
+	nzb, err := u.nzbStorage.GetNZB(nzoID)
+	if err != nil {
+		return nil // Can't determine status, let streaming proceed
+	}
+	for _, f := range nzb.Files {
+		if f.Name == filename && f.IsDeleted {
+			permanentErr := fmt.Errorf("file %s is permanently unavailable on Usenet", filename)
+			u.failedFiles.Store(key, permanentErr) // Populate cache to avoid future disk reads
+			return customerror.NewArticleNotFoundError(permanentErr)
+		}
+	}
+	return nil
 }
 
 func (u *Usenet) getFiles(nzoID string, filenames []string) (map[string]*storage.NZBFile, error) {
@@ -661,8 +714,8 @@ func (u *Usenet) Stream(ctx context.Context, nzoID, filename string, start, end 
 
 	// Mark file as failed if article not found (permanent error)
 	if err != nil && nntp.IsArticleNotFoundError(err) {
-		u.failedFiles.Store(key, err) // Reuse pre-computed key
-		// Wrap error to mark as permanent
+		u.failedFiles.Store(key, err)
+		u.markNZBFileDeleted(nzoID, filename) // Persist so status survives restarts
 		return customerror.NewArticleNotFoundError(err)
 	}
 


### PR DESCRIPTION
## Problem

Three issues affecting Usenet/NZB downloads:

1. **Missing articles crash the batch downloader**: an NNTP 430 "article not found" error was unhandled, causing the entire NZB batch to abort with an unrecoverable error.

2. **WebDAV streaming stuck on NNTP 430**: when streaming an NZB via WebDAV and an article was missing, the read would block indefinitely waiting for data that would never arrive.

3. **NZB ffprobe D-state deadlock**: Sonarr calls ffprobe on newly imported symlinks that point to rclone-mounted debrid storage. If the debrid CDN returns a 429, ffprobe enters a D (uninterruptible sleep) state waiting for I/O. This blocked the completeEntry goroutine indefinitely, preventing any further processing of that entry and eventually starving the worker pool.

## Fix

**1efbf8b - Handle missing Usenet articles gracefully in NZB batch downloads**
- NNTP 430 responses are treated as permanent per-file failures
- The batch continues with remaining articles; the entry is marked partial

**4c83db9 - Fix WebDAV stuck on NNTP 430 article-not-found**
- WebDAV read path now detects 430 and returns EOF cleanly instead of blocking

**b573e1d - Prevent NZB ffprobe D-state deadlock from blocking completeEntry**
- completeEntry no longer waits synchronously for ffprobe-related I/O
- The worker goroutine is released immediately; ffprobe can complete (or be killed) in the background

## Context

The ffprobe issue is particularly impactful for debrid+arr setups: Sonarr deletes the old file before confirming the import succeeds. If ffprobe deadlocks, the import never completes, leaving the episode with no file at all. Combined with the CDN URL caching fix in PR #324, this eliminates the data-loss scenario.
