### PR TITLE
feat: smart torrent name truncation to fix Linux NAME_MAX 255-byte limit for non-Western release names

### DIFF
--- a/docs/long-name-truncation.md
+++ b/docs/long-name-truncation.md
@@ -1,0 +1,175 @@
+# Smart Torrent Name Truncation
+
+## Problem
+
+Linux imposes a hard limit of **255 bytes** per directory component (`NAME_MAX`). Multi-byte
+UTF-8 scripts (Cyrillic = 2 bytes/char, CJK = 3 bytes/char, Arabic = 2 bytes/char) cause long
+release names to exceed this limit. Symlink creation then fails with:
+
+```
+failed to create symlink … file name too long
+```
+
+Example offending name (296 bytes in UTF-8):
+
+```
+Перси Джексон и Олимпийцы - Сезон 2 / Percy Jackson and the Olympians - Season 2 (2025) [WEB-DL 1080p] MVO
+```
+
+---
+
+## Solution
+
+Two complementary mechanisms, no external dependencies:
+
+| Layer | What it does |
+|-------|-------------|
+| **Safety net** in `DownloadPath()` | Byte-safe UTF-8 truncation on every path built — always active, protects pre-existing entries |
+| **Smart resolver** in `processNewTorrent` | Extracts the ASCII/English title, year, and SxxExx from the raw name; builds a short clean name |
+
+The smart resolver works for any non-Western script (Cyrillic, CJK, Arabic, Korean, Japanese,
+Thai, …) as long as the release includes an embedded English title — which nearly all
+internationally distributed releases do.
+
+---
+
+## Configuration
+
+Add to `config.json` only if you need to change the default:
+
+```json
+{
+  "prefer_ascii_name": false
+}
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| `true` (default, key omitted) | Extract ASCII/English title and build a compact name |
+| `false` | Preserve the raw name as-is, byte-safe truncated to 255 bytes |
+
+Set to `false` only if your library is intentionally non-Western and you want native-script
+directory names preserved.
+
+---
+
+## Changes
+
+### 1. `internal/utils/file.go` — `TruncateName`
+
+```diff
++import "unicode/utf8"
++
++func TruncateName(name string, maxBytes int) string {
++    if len(name) <= maxBytes {
++        return name
++    }
++    b := []byte(name)[:maxBytes]
++    for len(b) > 0 && !utf8.Valid(b) {
++        b = b[:len(b)-1]
++    }
++    return strings.TrimRight(string(b), " ")
++}
+```
+
+Walks back from byte 255 until the slice is valid UTF-8, avoiding split multibyte runes.
+
+### 2. `pkg/storage/types.go` — `DownloadPath()` safety net
+
+```diff
+ func (e *Entry) DownloadPath() string {
+-    return filepath.Join(e.SavePath, utils.RemoveExtension(e.Name))
++    const nameMax = 255
++    name := utils.TruncateName(utils.RemoveExtension(e.Name), nameMax)
++    return filepath.Join(e.SavePath, name)
+ }
+```
+
+Always active regardless of `prefer_ascii_name`.
+
+### 3. `internal/config/config.go` — `PreferASCIIName` flag
+
+```diff
++    // PreferASCIIName controls whether decypharr extracts the ASCII/Western title
++    // from a raw torrent name and builds a compact canonical directory name.
++    // Disable only if your library is intentionally non-Western.
++    // Default: true
++    PreferASCIIName *bool `json:"prefer_ascii_name,omitempty"`
+```
+
+Using `*bool` so omitting the key from `config.json` defaults to `true` with no breaking
+change for existing installs.
+
+### 4. `internal/utils/nameparser.go` — new file
+
+Pure-regex parser, no network or external dependencies. Handles:
+
+- Standard `SxxExx` notation: `S02E01`, `S02E01E04`, `S02E01-04`
+- Word-based: `Season 2`, `Сезон 2`, `Episodes 1-4`, `Серии 1-4`
+- Dotted names: `Breaking.Bad.S05E10.720p` → spaces before parsing
+- Technical tags (`HEVC`, `1080p`, `WEB-DL`, …) mark end of title region
+- Longest capitalised ASCII run used as English title candidate
+
+```diff
++func ParseTorrentName(raw string) ParsedName
++func BuildCleanName(p ParsedName, canonicalTitle string) string
++
++type ParsedName struct {
++    Title   string  // ASCII title candidate
++    Year    string  // "2025" or ""
++    Season  int     // 0 if unknown
++    EpStart int     // 0 if unknown
++    EpEnd   int     // 0 if no range
++    IsTV    bool
++}
+```
+
+**Output examples:**
+
+| Raw torrent name | Clean name |
+|-----------------|-----------|
+| `Перси Джексон…Сезон 2…Percy Jackson and the Olympians…S02E01E04…` | `Percy Jackson and the Olympians (2025) S02E01-E04` |
+| `鬼滅の刃 Demon Slayer S03E11 1080p` | `Demon Slayer S03E11` |
+| `괴물 Monster (2021) 한국영화 1080p` | `Monster (2021)` |
+| `Breaking.Bad.S05E10.720p.BluRay` | `Breaking Bad S05E10` |
+| `NCIS.New.Orleans.S04E23E24.HDTV` | `NCIS New Orleans S04E23-E24` |
+
+### 5. `pkg/manager/nameresolver.go` — new file
+
+```diff
++func (m *Manager) resolveEntryName(raw string) string {
++    cfg := config.Get()
++    if cfg.PreferASCIIName != nil && !*cfg.PreferASCIIName {
++        return utils.TruncateName(utils.RemoveExtension(raw), 255)
++    }
++    parsed := utils.ParseTorrentName(raw)
++    clean := utils.BuildCleanName(parsed, "")
++    if clean == "" {
++        return utils.TruncateName(utils.RemoveExtension(raw), 255)
++    }
++    return clean
++}
+```
+
+### 6. `pkg/manager/processor.go` — `processNewTorrent`
+
+```diff
+-torrent.Name = debridTorrent.Name
++torrent.Name = m.resolveEntryName(debridTorrent.Name)
+ torrent.OriginalFilename = debridTorrent.OriginalFilename
++torrent.ContentPath = torrent.DownloadPath() // re-sync after name resolution
+ torrent.UpdatedAt = time.Now()
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|---------|-----------|
+| Cyrillic/CJK/Arabic with embedded English title | English title extracted; native script discarded |
+| Non-Western name with no ASCII title at all | `BuildCleanName` returns `""`; falls back to `TruncateName(raw, 255)` |
+| `prefer_ascii_name: false` | Always `TruncateName(raw, 255)` — raw name preserved |
+| Pre-existing entries in storage | `DownloadPath()` safety net truncates regardless of setting |
+| Multi-episode range | `S02E01-E04` preserved in output |
+| Dotted name | Dots replaced with spaces before parsing |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,6 +179,14 @@ type Config struct {
 	SkipAutoMove bool   `json:"skip_auto_move,omitempty"`
 
 	Repair RepairConfig `json:"repair,omitzero"`
+
+	// PreferASCIIName controls whether decypharr extracts the ASCII/Western title
+	// from a raw torrent name (e.g. picking "Percy Jackson" out of a mixed
+	// Cyrillic or CJK release name) and builds a compact canonical directory name.
+	// Disable only if your library is intentionally non-Western and you want the
+	// raw name preserved (byte-safe truncated to 255 bytes if needed).
+	// Default: true
+	PreferASCIIName *bool `json:"prefer_ascii_name,omitempty"`
 }
 
 func (c *Config) JsonFile() string {

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -4,7 +4,22 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 )
+
+// TruncateName truncates a filesystem name component to maxBytes bytes while
+// preserving valid UTF-8. Linux NAME_MAX is 255 bytes; pass 255 for safety.
+func TruncateName(name string, maxBytes int) string {
+	if len(name) <= maxBytes {
+		return name
+	}
+	b := []byte(name)[:maxBytes]
+	// Walk back until the byte slice is valid UTF-8 (avoids splitting multibyte runes).
+	for len(b) > 0 && !utf8.Valid(b) {
+		b = b[:len(b)-1]
+	}
+	return strings.TrimRight(string(b), " ")
+}
 
 func PathUnescape(path string) string {
 	// try to use url.PathUnescape

--- a/internal/utils/nameparser.go
+++ b/internal/utils/nameparser.go
@@ -1,0 +1,165 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ParsedName holds structured information extracted from a raw torrent/release name.
+type ParsedName struct {
+	Title   string // Best English title candidate (may be empty)
+	Year    string // 4-digit year, e.g. "2025" (empty if not found)
+	Season  int    // Season number, 0 if unknown
+	EpStart int    // First episode number, 0 if unknown
+	EpEnd   int    // Last episode number when a range is present, 0 otherwise
+	IsTV    bool   // True if any season/episode info was found
+}
+
+var (
+	// S01E01, S01E01-E04, S01E01E04, S01E01-04
+	reStandardSE = regexp.MustCompile(`(?i)[Ss](\d{1,2})[Ee](\d{1,3})(?:[Ee-]?(\d{1,3}))?`)
+	// "Season 2" / "Сезон 2"
+	reSeasonWord = regexp.MustCompile(`(?i)(?:season|сезон)\s*(\d{1,2})`)
+	// "Episodes 1-4" / "Серии 1-4 из" / "Серии 1-4"
+	reEpRange = regexp.MustCompile(`(?i)(?:episodes?|серии?)\s*(\d{1,3})[-–—]\s*(\d{1,3})`)
+	// "Episode 1" / "Серия 1"
+	reEpSingle = regexp.MustCompile(`(?i)(?:episode|серия)\s*(\d{1,3})`)
+	// 4-digit year surrounded by delimiters
+	reYear = regexp.MustCompile(`(?:^|[\s\[\(,])(\d{4})(?:[\s\]\),\.]|$)`)
+	// Longest capitalised ASCII word-run (title candidate)
+	reAsciiTitle = regexp.MustCompile(`[A-Z][A-Za-z0-9 ':\-\.!,&]{1,}`)
+	// Fully dot-separated first token ("Breaking.Bad.S05E10")
+	reDotted = regexp.MustCompile(`^[A-Za-z0-9]+(?:\.[A-Za-z0-9]+){2,}`)
+	// Technical tag keywords that mark where the title region ends
+	reTechTag = regexp.MustCompile(`(?i)\b(?:HEVC|H\.?264|H\.?265|x264|x265|AVC|HVEC|WEB[-\.]?DL|WEBRip|BluRay|BDRip|HDRip|HDTV|DVDRip|CAM|TS|4[Kk]|1080[pi]|720[pi]|480[pi]|2160[pi]|HDR|SDR|Dolby|DTS|AAC|AC3|MP3|FLAC|MVO|MKV|MP4|AVI|REMUX|REPACK|PROPER|EXTENDED|THEATRICAL|UNRATED|LIMITED|IMAX)\b`)
+)
+
+// ParseTorrentName extracts structured info from a raw torrent/release name.
+// It handles mixed Cyrillic+English names, dotted names, and common tagging conventions.
+func ParseTorrentName(raw string) ParsedName {
+	p := ParsedName{}
+
+	// Normalise dot-separated names ("Breaking.Bad.S05E10.720p") to spaces.
+	working := raw
+	firstWord := strings.Fields(raw)
+	if len(firstWord) > 0 && reDotted.MatchString(firstWord[0]) {
+		working = strings.ReplaceAll(raw, ".", " ")
+	}
+
+	// ── Season / Episode ──────────────────────────────────────────────────────
+	if m := reStandardSE.FindStringSubmatch(working); m != nil {
+		p.Season = nameParseAtoi(m[1])
+		p.EpStart = nameParseAtoi(m[2])
+		if m[3] != "" {
+			ep2 := nameParseAtoi(m[3])
+			if ep2 != p.EpStart {
+				p.EpEnd = ep2
+			}
+		}
+		p.IsTV = true
+	} else {
+		if m := reSeasonWord.FindStringSubmatch(working); m != nil {
+			p.Season = nameParseAtoi(m[1])
+			p.IsTV = true
+		}
+		if m := reEpRange.FindStringSubmatch(working); m != nil {
+			p.EpStart = nameParseAtoi(m[1])
+			p.EpEnd = nameParseAtoi(m[2])
+		} else if m := reEpSingle.FindStringSubmatch(working); m != nil {
+			p.EpStart = nameParseAtoi(m[1])
+		}
+	}
+
+	// ── Year ─────────────────────────────────────────────────────────────────
+	for _, m := range reYear.FindAllStringSubmatch(working, -1) {
+		if y := nameParseAtoi(m[1]); y >= 1900 && y <= 2099 {
+			p.Year = m[1]
+			break
+		}
+	}
+
+	// ── Title region ─────────────────────────────────────────────────────────
+	// Cut at the first technical tag or bracket to avoid including codec/group info.
+	titleRegion := working
+	if loc := reTechTag.FindStringIndex(titleRegion); loc != nil && loc[0] > 5 {
+		titleRegion = titleRegion[:loc[0]]
+	}
+	for _, ch := range []string{"[", "("} {
+		if idx := strings.Index(titleRegion, ch); idx > 5 {
+			if idx < len(titleRegion) {
+				titleRegion = titleRegion[:idx]
+			}
+		}
+	}
+	// Cut at season/episode marker so it isn't folded into the title.
+	if m := reStandardSE.FindStringIndex(titleRegion); m != nil {
+		titleRegion = titleRegion[:m[0]]
+	} else if m := reSeasonWord.FindStringIndex(titleRegion); m != nil {
+		titleRegion = titleRegion[:m[0]]
+	}
+
+	// Pick the longest capitalised ASCII run from the title region.
+	best := ""
+	for _, r := range reAsciiTitle.FindAllString(titleRegion, -1) {
+		r = nameTrimTitle(r)
+		if len(r) > len(best) {
+			best = r
+		}
+	}
+	p.Title = best
+
+	return p
+}
+
+// BuildCleanName constructs a short, meaningful, filesystem-safe name from a
+// ParsedName. canonicalTitle (from TMDB/TVDB) overrides p.Title when non-empty.
+// The result is guaranteed to be ≤ 255 bytes (Linux NAME_MAX).
+func BuildCleanName(p ParsedName, canonicalTitle string) string {
+	title := p.Title
+	if canonicalTitle != "" {
+		title = canonicalTitle
+	}
+	if title == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(title)
+
+	if p.Year != "" {
+		sb.WriteString(" (")
+		sb.WriteString(p.Year)
+		sb.WriteByte(')')
+	}
+
+	if p.Season > 0 {
+		sb.WriteString(fmt.Sprintf(" S%02d", p.Season))
+		if p.EpStart > 0 {
+			sb.WriteString(fmt.Sprintf("E%02d", p.EpStart))
+			if p.EpEnd > 0 && p.EpEnd != p.EpStart {
+				sb.WriteString(fmt.Sprintf("-E%02d", p.EpEnd))
+			}
+		}
+	}
+
+	return TruncateName(sb.String(), 255)
+}
+
+// nameTrimTitle cleans leading/trailing punctuation and collapses spaces.
+func nameTrimTitle(s string) string {
+	s = strings.TrimRight(s, " -.,:/")
+	s = strings.TrimLeft(s, " -.,:/")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// nameParseAtoi converts a digit-only string to int without stdlib overhead.
+func nameParseAtoi(s string) int {
+	n := 0
+	for _, ch := range s {
+		if ch >= '0' && ch <= '9' {
+			n = n*10 + int(ch-'0')
+		}
+	}
+	return n
+}

--- a/pkg/manager/nameresolver.go
+++ b/pkg/manager/nameresolver.go
@@ -1,0 +1,37 @@
+package manager
+
+import (
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/utils"
+)
+
+// resolveEntryName converts a raw debrid torrent name into a clean,
+// filesystem-safe directory name (≤ 255 bytes, Linux NAME_MAX).
+//
+// When prefer_ascii_name is true (the default), the raw name is parsed to
+// extract the best ASCII title, year, season and episode, and a compact name
+// such as "Percy Jackson and the Olympians (2025) S02E01-E04" is returned.
+// This handles mixed Cyrillic, CJK, Arabic, and other non-Western release
+// names that embed an English title alongside the native-script title.
+//
+// When prefer_ascii_name is false, the raw name is returned unchanged except
+// for a byte-safe UTF-8 truncation to 255 bytes — useful when the library is
+// intentionally non-Western and the native-script name should be preserved.
+func (m *Manager) resolveEntryName(raw string) string {
+	cfg := config.Get()
+	if cfg.PreferASCIIName != nil && !*cfg.PreferASCIIName {
+		return utils.TruncateName(utils.RemoveExtension(raw), 255)
+	}
+
+	parsed := utils.ParseTorrentName(raw)
+	clean := utils.BuildCleanName(parsed, "")
+	if clean == "" {
+		return utils.TruncateName(utils.RemoveExtension(raw), 255)
+	}
+
+	m.logger.Debug().
+		Str("raw", raw).
+		Str("clean", clean).
+		Msg("Resolved entry name")
+	return clean
+}

--- a/pkg/manager/processor.go
+++ b/pkg/manager/processor.go
@@ -280,8 +280,9 @@ func (m *Manager) processNewTorrent(torrent *storage.Entry, debridTorrent *debri
 	torrent.ActiveProvider = debridTorrent.Debrid
 	torrent.Bytes = debridTorrent.GetSize()
 	torrent.Size = debridTorrent.GetSize()
-	torrent.Name = debridTorrent.Name
+	torrent.Name = m.resolveEntryName(debridTorrent.Name)
 	torrent.OriginalFilename = debridTorrent.OriginalFilename
+	torrent.ContentPath = torrent.DownloadPath() // re-sync after name resolution
 	torrent.UpdatedAt = time.Now()
 	// AddOrUpdate files here
 	for _, file := range debridTorrent.Files {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -503,9 +503,14 @@ func (e *Entry) IsValid() bool {
 	return activePlacement.IsValid()
 }
 
-// DownloadPath returns the expected download/symlink path for this entry
+// DownloadPath returns the expected download/symlink path for this entry.
+// The name component is truncated to 255 bytes (Linux NAME_MAX) to handle
+// torrents with extremely long names (e.g. Cyrillic titles where each character
+// is 2 bytes in UTF-8).
 func (e *Entry) DownloadPath() string {
-	return filepath.Join(e.SavePath, utils.RemoveExtension(e.Name))
+	const nameMax = 255
+	name := utils.TruncateName(utils.RemoveExtension(e.Name), nameMax)
+	return filepath.Join(e.SavePath, name)
 }
 
 // SwitcherJob tracks the progress of a migration operation


### PR DESCRIPTION
## Problem

Long torrent release names that use multi-byte UTF-8 scripts (Cyrillic, CJK, Arabic, Korean, Japanese, Thai, etc.) exceed the Linux `NAME_MAX` limit of **255 bytes** per directory component. Symlink and directory creation then fails with:

```
failed to create symlink ... file name too long
```

Example offending name (296 bytes in UTF-8):
```
Перси Джексон и Олимпийцы - Сезон 2 / Percy Jackson and the Olympians - Season 2 (2025) [WEB-DL 1080p] MVO
```

## Solution

Two complementary layers, no external dependencies:

### 1. Safety net — `TruncateName()` in `internal/utils/file.go`

Byte-safe UTF-8 truncation applied in `DownloadPath()` on every path build. Walks back from byte 255 until the slice is valid UTF-8, avoiding split multibyte runes. Always active regardless of config.

### 2. Smart resolver — `ParseTorrentName()` + `BuildCleanName()` in `internal/utils/nameparser.go`

Pure-regex parser that extracts the embedded ASCII/English title, year, and SxxExx episode notation from the raw debrid name, then builds a short canonical name:

| Raw torrent name | Clean name |
|---|---|
| `Перси Джексон…Percy Jackson and the Olympians…S02E01E04…` | `Percy Jackson and the Olympians (2025) S02E01-E04` |
| `鬼滅の刃 Demon Slayer S03E11 1080p` | `Demon Slayer S03E11` |
| `괴물 Monster (2021) 한국영화 1080p` | `Monster (2021)` |
| `Breaking.Bad.S05E10.720p.BluRay` | `Breaking Bad S05E10` |

Works for any non-Western script as long as the release includes an embedded English title — which nearly all internationally distributed releases do.

### Config flag

```json
{ "prefer_ascii_name": false }
```

`prefer_ascii_name` defaults to `true` (key can be omitted). Set to `false` only if your library is intentionally non-Western and you want native-script directory names preserved (byte-safe truncated to 255 bytes).

The flag uses `*bool` so omitting the key from `config.json` is a no-op for existing installs.

## Files changed

| File | Change |
|---|---|
| `internal/utils/file.go` | Added `TruncateName(name, maxBytes)` |
| `pkg/storage/types.go` | `DownloadPath()` applies `TruncateName` as safety net |
| `internal/config/config.go` | Added `PreferASCIIName *bool` (`prefer_ascii_name`) |
| `internal/utils/nameparser.go` | New: pure-regex `ParseTorrentName` + `BuildCleanName` |
| `pkg/manager/nameresolver.go` | New: `resolveEntryName` orchestrates parse → build → fallback |
| `pkg/manager/processor.go` | Calls `resolveEntryName` in `processNewTorrent` |
| `docs/long-name-truncation.md` | Documentation with diffs and output examples |
