### PR TITLE
fix(torbox): proactive 300 req/min rate limit, Retry-After backoff, and retry logging

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -169,6 +170,40 @@ func (c *Client) Get(url string) (*http.Response, error) {
 	return c.Do(req)
 }
 
+// zerologAdapter bridges zerolog to the retryablehttp.Logger interface so that
+// retry events (including 429 backoffs) appear in decypharr's structured log.
+type zerologAdapter struct{ log zerolog.Logger }
+
+func (z zerologAdapter) Printf(format string, args ...interface{}) {
+	z.log.Debug().Msgf(format, args...)
+}
+
+// retryAfterBackoff extends DefaultBackoff with Retry-After header support.
+// When a 429 response carries a Retry-After header decypharr waits exactly as
+// long as the server requests instead of using jittered exponential backoff.
+func retryAfterBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
+				wait := time.Duration(secs) * time.Second
+				if wait > max {
+					return max
+				}
+				return wait
+			}
+			if t, err := http.ParseTime(ra); err == nil {
+				if wait := time.Until(t); wait > 0 {
+					if wait > max {
+						return max
+					}
+					return wait
+				}
+			}
+		}
+	}
+	return retryablehttp.DefaultBackoff(min, max, attemptNum, resp)
+}
+
 // New creates a new HTTP client with the specified options
 func New(options ...ClientOption) *Client {
 	client := &Client{
@@ -230,7 +265,8 @@ func New(options ...ClientOption) *Client {
 	retryClient.RetryMax = client.maxRetries
 	retryClient.RetryWaitMin = 1 * time.Second
 	retryClient.RetryWaitMax = 30 * time.Second
-	retryClient.Logger = nil // Disable default logging
+	retryClient.Logger = zerologAdapter{log: client.logger}
+	retryClient.Backoff = retryAfterBackoff
 
 	// Custom retry policy based on retryable status codes
 	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {

--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -62,11 +62,20 @@ func New(dc config.Debrid, ratelimits map[string]ratelimit.Limiter) (*Torbox, er
 	}
 	_log := logger.New(dc.Name)
 
+	// TorBox enforces a hard cap of 300 req/min per API key, applied
+	// synchronously across all servers since v8.4 (Feb 2026, GAP-002).
+	// Default to that limit if the user has not configured one explicitly.
+	mainRL := ratelimits["main"]
+	if mainRL == nil {
+		mainRL = ratelimit.New(300, ratelimit.Per(time.Minute), ratelimit.WithSlack(30))
+	}
+
 	opts := []request.ClientOption{
 		request.WithHeaders(headers),
-		request.WithRateLimiter(ratelimits["main"]),
+		request.WithRateLimiter(mainRL),
 		request.WithMaxRetries(cfg.Retries),
 		request.WithRetryableStatus(http.StatusTooManyRequests, http.StatusBadGateway),
+		request.WithLogger(_log),
 	}
 	if dc.Proxy != "" {
 		opts = append(opts, request.WithProxy(dc.Proxy))


### PR DESCRIPTION
## GAP-002 — Full implementation of TorBox 300 req/min per-key rate limit

TorBox changed rate limiting to **per-API-key, synchronous across all servers** in v8.4 (Feb 2026). The hard cap is **300 requests/minute per API key**. Three gaps remained after the initial 429 retry work:

---

### 1. No proactive rate limiter when `rate_limit` is omitted from config

`ParseRateLimit("")` returns `nil`, so TorBox clients with no explicit `rate_limit` in `config.json` had zero throttling — every goroutine hammered the API freely until 429s arrived.

**Fix:** `torbox.New()` now defaults to `300/minute` (with 10% burst slack) when no rate limiter is passed in. Users who set an explicit `rate_limit` continue to use their configured value.

```go
mainRL := ratelimits["main"]
if mainRL == nil {
    mainRL = ratelimit.New(300, ratelimit.Per(time.Minute), ratelimit.WithSlack(30))
}
```

---

### 2. `Retry-After` header ignored on 429 responses

`retryablehttp` used jittered exponential backoff regardless of what the server actually requested. If TorBox said "wait 12 seconds", decypharr might retry after 1 second and immediately hit another 429.

**Fix:** `retryAfterBackoff()` in `internal/request/request.go` parses the `Retry-After` header as either an integer (seconds) or an HTTP date, and sleeps exactly that long. Falls back to `DefaultBackoff` when the header is absent.

This function is wired into **all** providers (not just TorBox) — any provider that sends `Retry-After` on 429 will benefit.

---

### 3. Retry events not logged

`retryClient.Logger = nil` suppressed all retry/backoff visibility. A 429 storm would produce no log output, making it impossible to diagnose.

**Fix:** `zerologAdapter` bridges zerolog to `retryablehttp.Logger`. Retry attempts, including 429 backoffs with wait duration, now appear in decypharr's structured debug log. The `WithLogger` option on the TorBox client wires the provider-namespaced logger so messages are tagged correctly.

---

### Files changed

| File | Change |
|---|---|
| `internal/request/request.go` | Added `zerologAdapter`, `retryAfterBackoff`, wired both into `New()` |
| `pkg/debrid/providers/torbox/torbox.go` | Default 300/min limiter in `New()`; added `request.WithLogger` |

Closes GAP-002. Related: PR #324 (CDN URL caching), PR #325 (download reliability retry).
