### PR TITLE
fix(torbox): remove trailing slash from /api/torrents/mylist/ to prevent 307 auth stripping

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -284,7 +284,7 @@ func (tb *Torbox) getTorboxStatus(status string, finished bool) types.TorrentSta
 func (tb *Torbox) GetTorrent(torrentId string) (*types.Torrent, error) {
 	var res InfoResponse
 
-	resp, err := tb.doGet("/api/torrents/mylist/", map[string]string{"id": torrentId}, &res)
+	resp, err := tb.doGet("/api/torrents/mylist", map[string]string{"id": torrentId}, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (tb *Torbox) loadDownloadPresent() error {
 func (tb *Torbox) UpdateTorrent(t *types.Torrent) error {
 	var res InfoResponse
 
-	resp, err := tb.doGet("/api/torrents/mylist/", map[string]string{"id": t.Id}, &res)
+	resp, err := tb.doGet("/api/torrents/mylist", map[string]string{"id": t.Id}, &res)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

`GetTorrent()` and `UpdateTorrent()` called `/api/torrents/mylist/` with a trailing slash.

Cloudflare returns a **307 redirect** for that URL (stripping the slash). Go's `http.Client` follows the redirect but **strips the `Authorization` header** on cross-path redirects, so the re-sent request arrives unauthenticated and fails.

`getTorrents()` and `loadDownloadPresent()` already used the correct URL without a trailing slash — this was an inconsistency between the two read paths and the single-item lookup paths.

## Fix

Remove the trailing slash from both call sites:

- `GetTorrent()` — `doGet(/api/torrents/mylist/, ...)` → `doGet(/api/torrents/mylist, ...)`
- `UpdateTorrent()` — same change

One-character fix per call site, no logic changes.

Fixes #309