### PR TITLE
fix(torbox): correct plan number mapping in GetProfile

### DIFF
--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -678,9 +678,9 @@ func (tb *Torbox) GetProfile() (*types.Profile, error) {
 	case 1:
 		profile.Type = "essential"
 	case 2:
-		profile.Type = "pro"
-	case 3:
 		profile.Type = "standard"
+	case 3:
+		profile.Type = "pro"
 	default:
 		profile.Type = "free"
 	}


### PR DESCRIPTION
## Summary

The `GetProfile()` function in `pkg/debrid/providers/torbox/torbox.go` had the plan integer-to-name mapping inverted for plans 2 and 3.

**Before (incorrect):**
```go
case 2:
    profile.Type = "pro"      // plan 2 was treated as top tier (10 slots)
case 3:
    profile.Type = "standard" // plan 3 was treated as middle tier (5 slots)
```

**After (correct):**
```go
case 2:
    profile.Type = "standard" // plan 2 = Standard (5 slots)
case 3:
    profile.Type = "pro"      // plan 3 = Pro (10 slots)
```

## Impact

TorBox plan integers ascend with tier: `1 = essential`, `2 = standard`, `3 = pro`. With the previous mapping, Standard subscribers (plan 2) were being assigned Pro-tier concurrent slot counts (10), and Pro subscribers (plan 3) were getting Standard slot counts (5), causing incorrect `minimum_free_slot` behaviour and potential over-scheduling for Standard users.

## Verification

Live TorBox API `/user/me` response returns `"plan": 2` for a Standard subscriber. The corrected mapping ensures the `planSlots` lookup (`essential: 3`, `standard: 5`, `pro: 10`) assigns the right slot budget per account tier.

> **Note:** TorBox does not publish enum values for the `plan` field in their public API docs. This fix is based on the natural ascending convention (lower integer = lower tier). If you have direct knowledge of the TorBox plan numbering, please verify before merging.