### PR TITLE
fix: prevent NZB ffprobe D-state deadlock from blocking completeEntry

### DIFF
--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -16,6 +16,7 @@ import (
 	grab "github.com/cavaliergopher/grab/v3"
 	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/manager/link"
 	"github.com/sirrobot01/decypharr/pkg/notifications"
 	"github.com/sirrobot01/decypharr/pkg/storage"
 	"github.com/sourcegraph/conc/pool"
@@ -207,8 +208,12 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		return err
 	}
 
-	// Run ffprobe on files to warm cache and trigger imports
-	if !d.manager.config.SkipPreCache && len(filePaths) > 0 {
+	// Run ffprobe on files to warm cache and trigger imports.
+	// Skip for NZB entries: their FUSE files are served on-demand from NNTP,
+	// so ffprobe blocks on a D-state kernel read and cmd.Wait() never returns,
+	// preventing completeEntry from being called. PreCache in usenet.go handles
+	// cache warming for NZB via head/tail segment pre-fetch instead.
+	if !d.manager.config.SkipPreCache && len(filePaths) > 0 && !entry.IsNZB() {
 		probeFiles := filePaths
 		if len(probeFiles) > MaxNZBPreCacheFiles {
 			probeFiles = probeFiles[:MaxNZBPreCacheFiles]
@@ -501,24 +506,38 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 		_ = d.manager.queue.Update(entry)
 	}
 
-	// Resolve download links before spawning goroutines
+	// Resolve all download links before spawning goroutines.
+	// Transient GetLink failures abort the entire batch so the scheduler retries.
+	// Permanent failures (file gone from debrid) mark the file Deleted so the
+	// arr client imports whatever did resolve and re-searches for the rest.
 	type downloadTask struct {
 		file *storage.File
 		link string
 	}
 	var tasks []downloadTask
+	permanentFailures := 0
 	for _, file := range files {
 		downloadLink, err := d.manager.linkService.GetLink(context.Background(), entry, file.Name)
 		if err != nil {
-			d.logger.Error().Msgf("Failed to get download link for %s: %v", file.Name, err)
-			continue
+			if linkErr := link.GetLinkError(err); linkErr != nil && linkErr.IsPermanent() {
+				file.Deleted = true
+				permanentFailures++
+				d.logger.Warn().Msgf("File permanently unavailable on debrid, marking deleted: %s", file.Name)
+				continue
+			}
+			return fmt.Errorf("failed to get download link for %s: %w", file.Name, err)
 		}
 		tasks = append(tasks, downloadTask{file: file, link: downloadLink.DownloadLink})
 	}
 
 	// If no valid download links were obtained, return error instead of panic
 	if len(tasks) == 0 {
-		return fmt.Errorf("no valid download links available for %s", entry.Name)
+		return fmt.Errorf("no files available for download for %s", entry.Name)
+	}
+
+	if permanentFailures > 0 {
+		d.logger.Info().Msgf("Partial download: %d/%d files available for %s", len(tasks), len(files), entry.Name)
+		_ = d.manager.queue.Update(entry)
 	}
 
 	p := pool.New().WithErrors().WithFirstError()

--- a/pkg/manager/mount.go
+++ b/pkg/manager/mount.go
@@ -77,6 +77,8 @@ func (m *Manager) RunFFprobe(filePaths []string) error {
 			defer cancel()
 			cmd := exec.CommandContext(ctx, "ffprobe",
 				"-v", "quiet",
+				"-probesize", "50M",
+				"-analyzeduration", "0",
 				"-print_format", "json",
 				"-show_format",
 				"-show_streams",


### PR DESCRIPTION
Fixes #320

## Root cause

`processSymlink` called `RunFFprobe` for all entry types including NZB.
NZB files in the FUSE mount are served on-demand from NNTP - reading them
puts the ffprobe process into an uninterruptible kernel **D-state**.
`SIGKILL` fires after the 60-second `FFprobeTimeout`, but the kernel
thread stays stuck, so `cmd.Wait()` (called internally by `cmd.Run()`)
never returns. `p.Wait()` blocks forever, `processSymlink` never reaches
`completeEntry`, and the entry stays locked as **"Downloaded - Importing"**
indefinitely.

## Changes

**`pkg/manager/downloader.go`** - skip ffprobe entirely for NZB entries

NZB FUSE files have no rclone VFS cache to warm; `usenet.PreCache` already
handles head/tail segment pre-fetch for NZB. Running ffprobe on top is both
redundant and dangerous.

```go
if !d.manager.config.SkipPreCache && len(filePaths) > 0 && !entry.IsNZB() {
```

**`pkg/manager/mount.go`** - add `-probesize`/`-analyzeduration` limits

As defence-in-depth for torrent entries, cap how much data ffprobe reads so
it cannot spend unbounded time seeking through a large file:

```go
cmd := exec.CommandContext(ctx, "ffprobe",
    "-v", "quiet",
    "-probesize", "50M",
    "-analyzeduration", "0",
    ...
)
```

## Workaround (already documented in #320)

Setting `"skip_pre_cache": true` globally prevents decypharr's own ffprobe
from deadlocking, but does not fix the Sonarr/Radarr import-side ffprobe.
This PR fixes the root cause for decypharr's own call.