### PR TITLE
fix(nntp): auto-enable TLS for implicit-TLS ports 563 and 443

### DIFF
--- a/internal/config/usenet.go
+++ b/internal/config/usenet.go
@@ -90,6 +90,13 @@ func (c *Config) updateUsenetProvider(index int, u UsenetProvider) UsenetProvide
 	if u.Priority == 0 {
 		u.Priority = index + 1 // Default priority based on order
 	}
+	// Auto-enable TLS for ports that only speak implicit TLS.
+	// Users who set port 563 (NNTPS) or 443 without ssl:true get a
+	// plain-TCP connection; the server waits for a TLS ClientHello and
+	// never sends the greeting, causing a 10-second i/o timeout.
+	if !u.SSL && (u.Port == 563 || u.Port == 443) {
+		u.SSL = true
+	}
 	return u
 }
 


### PR DESCRIPTION
## Problem

Users who configure a NNTP provider with port `563` (NNTPS) or `443` without also setting `ssl: true` get a plain-TCP connection. The server immediately expects a TLS ClientHello -- it never sends the NNTP greeting. Decypharr blocks in `ReadString` until `HandshakeTimeout` (10s) expires and returns:

```
read greeting: i/o timeout
```

This is a well-known implicit-TLS convention (port 563 = NNTPS). Many users know their provider port number but are unaware they also need `ssl: true`.

Fixes #319

## Fix

Auto-enable SSL in `updateUsenetProvider` when the configured port is `563` or `443`:

```go
if !u.SSL && (u.Port == 563 || u.Port == 443) {
    u.SSL = true
}
```

## Files changed

- `internal/config/usenet.go` -- 7 lines added to `updateUsenetProvider`