### PR TITLE
fix(downloader): retry GetLink on 429 with pausedDL backoff; handle CDN expiry

### DIFF
--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -249,6 +249,26 @@ Mount configuration determines how files are exposed on the filesystem.
 
 Connect to an existing Rclone instance's RC API.
 
+## Download Behaviour
+
+```json
+{
+  "max_downloads": 4,
+  "download_folder": "/downloads",
+  "default_download_action": "symlink",
+  "rate_limit_retries": 3
+}
+```
+
+| Field | Type | Description | Default |
+|---|---|---|---|
+| `max_downloads` | int | Max concurrent file downloads | `0` (unlimited) |
+| `download_folder` | string | Destination for downloaded files | Required when action is `download` |
+| `default_download_action` | string | `symlink`, `download`, `strm`, or `none` | `symlink` |
+| `rate_limit_retries` | int | How many times to retry a `GetLink` call that returns HTTP 429 before failing the whole job. Between retries the entry is reported as **paused** to the arr (so it does not remove or re-grab the item). Backoff: 30 s → 60 s → 120 s, capped at 5 min. Set to `0` to disable retry and fail immediately on 429. | `3` |
+
+**Environment variable:** `DECYPHARR_RATE_LIMIT_RETRIES=3`
+
 ## Health Checker
 
 ```json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,14 @@ type Config struct {
 	Retries      int    `json:"retries,omitempty"`
 	SkipAutoMove bool   `json:"skip_auto_move,omitempty"`
 
+	// RateLimitRetries controls how many times processTorrentDownload will retry
+	// a GetLink call that returns HTTP 429 (Too Many Requests) before failing the
+	// whole job. Each retry waits with exponential backoff (30 s, 60 s, 120 s …
+	// capped at 5 min) and reports the entry as "paused" to the arr client during
+	// the wait so the arr does not remove or re-grab the item.
+	// Set to 0 to disable the retry behaviour and fail immediately on 429.
+	RateLimitRetries int `json:"rate_limit_retries,omitempty"`
+
 	Repair RepairConfig `json:"repair,omitzero"`
 }
 
@@ -455,6 +463,10 @@ func (c *Config) setDefaults() {
 	// Set default error threshold for multi-debrid switching
 	if c.Retries == 0 {
 		c.Retries = 3 // Default to 3 consecutive errors before switching
+	}
+
+	if c.RateLimitRetries == 0 {
+		c.RateLimitRetries = 3 // Default: retry up to 3 times on HTTP 429 with 30s/60s/120s backoff
 	}
 
 	// Basic defaults

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -75,6 +75,11 @@ func (c *Config) applyEnvOverrides() {
 			c.Retries = v
 		}
 	}
+	if val := getEnv("RATE_LIMIT_RETRIES"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			c.RateLimitRetries = v
+		}
+	}
 
 	if val := getEnv("SKIP_AUTO_MOVE"); val != "" {
 		c.SkipAutoMove = parseBool(val)

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -510,13 +510,14 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 	for _, file := range files {
 		downloadLink, err := d.manager.linkService.GetLink(context.Background(), entry, file.Name)
 		if err != nil {
-			d.logger.Error().Msgf("Failed to get download link for %s: %v", file.Name, err)
-			continue
+			// A partial link failure means the download would be incomplete.
+			// Return an error so the arr client knows to retry rather than
+			// marking the torrent as fully downloaded with missing files.
+			return fmt.Errorf("failed to get download link for %s: %w", file.Name, err)
 		}
 		tasks = append(tasks, downloadTask{file: file, link: downloadLink.DownloadLink})
 	}
 
-	// If no valid download links were obtained, return error instead of panic
 	if len(tasks) == 0 {
 		return fmt.Errorf("no valid download links available for %s", entry.Name)
 	}

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -16,18 +16,21 @@ import (
 	grab "github.com/cavaliergopher/grab/v3"
 	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/debrid/types"
+	"github.com/sirrobot01/decypharr/pkg/manager/link"
 	"github.com/sirrobot01/decypharr/pkg/notifications"
 	"github.com/sirrobot01/decypharr/pkg/storage"
 	"github.com/sourcegraph/conc/pool"
 )
 
 type Downloader struct {
-	manager      *Manager
-	strmURL      string
-	mountPath    string
-	dest         string
-	logger       zerolog.Logger
-	maxDownloads int
+	manager          *Manager
+	strmURL          string
+	mountPath        string
+	dest             string
+	logger           zerolog.Logger
+	maxDownloads     int
+	rateLimitRetries int
 }
 
 const (
@@ -66,12 +69,13 @@ func NewDownloadManager(manager *Manager) *Downloader {
 		strmURL = fmt.Sprintf("http://%s:%s", bindAddress, cfg.Port)
 	}
 	return &Downloader{
-		manager:      manager,
-		strmURL:      strmURL,
-		mountPath:    cfg.Mount.MountPath,
-		logger:       manager.logger.With().Str("component", "downloader").Logger(),
-		dest:         cfg.DownloadFolder,
-		maxDownloads: cfg.MaxDownloads,
+		manager:          manager,
+		strmURL:          strmURL,
+		mountPath:        cfg.Mount.MountPath,
+		logger:           manager.logger.With().Str("component", "downloader").Logger(),
+		dest:             cfg.DownloadFolder,
+		maxDownloads:     cfg.MaxDownloads,
+		rateLimitRetries: cfg.RateLimitRetries,
 	}
 }
 
@@ -501,21 +505,55 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 		_ = d.manager.queue.Update(entry)
 	}
 
-	// Resolve download links before spawning goroutines
+	// Resolve download links before spawning goroutines.
+	// If any GetLink call returns HTTP 429 (rate-limited), the entry is reported
+	// as "paused" to the arr so it holds the item in queue, then the request is
+	// retried after an exponential backoff. The validated-link cache is cleared
+	// before each retry so that a CDN URL that expired during the pause is
+	// re-fetched from the debrid provider rather than re-validated stale.
 	type downloadTask struct {
 		file *storage.File
 		link string
 	}
 	var tasks []downloadTask
 	for _, file := range files {
-		downloadLink, err := d.manager.linkService.GetLink(context.Background(), entry, file.Name)
-		if err != nil {
-			// A partial link failure means the download would be incomplete.
-			// Return an error so the arr client knows to retry rather than
-			// marking the torrent as fully downloaded with missing files.
-			return fmt.Errorf("failed to get download link for %s: %w", file.Name, err)
+		var dlLink types.DownloadLink
+		var lastErr error
+		for attempt := 0; ; attempt++ {
+			dlLink, lastErr = d.manager.linkService.GetLink(context.Background(), entry, file.Name)
+			if lastErr == nil {
+				break
+			}
+			le := link.GetLinkError(lastErr)
+			if le == nil || !le.ShouldRetry() || attempt >= d.rateLimitRetries {
+				// Non-retryable error or retries exhausted — abort the whole job.
+				// A partial link failure means the download would be incomplete;
+				// the arr keeps the entry in queue and will retry.
+				return fmt.Errorf("failed to get download link for %s: %w", file.Name, lastErr)
+			}
+			backoff := rateLimitBackoff(attempt)
+			d.logger.Warn().
+				Str("file", file.Name).
+				Int("attempt", attempt+1).
+				Int("max_retries", d.rateLimitRetries).
+				Dur("backoff", backoff).
+				Msg("GetLink rate-limited (429), pausing download before retry")
+			entry.State = storage.EntryStatePausedDL
+			_ = d.manager.queue.Update(entry)
+			select {
+			case <-time.After(backoff):
+			case <-d.operationContext().Done():
+				return d.operationContext().Err()
+			}
+			// Clear the validation cache so the next attempt re-validates the CDN
+			// URL rather than re-using a stale 429 result. If the CDN URL expired
+			// during the pause, re-validation will detect a 400/403 and trigger a
+			// fresh link fetch from the debrid API automatically.
+			d.manager.linkService.Clear()
+			entry.State = storage.EntryStateDownloading
+			_ = d.manager.queue.Update(entry)
 		}
-		tasks = append(tasks, downloadTask{file: file, link: downloadLink.DownloadLink})
+		tasks = append(tasks, downloadTask{file: file, link: dlLink.DownloadLink})
 	}
 
 	if len(tasks) == 0 {
@@ -801,6 +839,21 @@ func (d *Downloader) buildDownloadLogMeta(req *http.Request, resp *http.Response
 	}
 	meta.statusCode = resp.StatusCode
 	return meta
+}
+
+// rateLimitBackoff returns the delay before the (attempt+1)-th retry on a 429
+// response. Backoff doubles each attempt starting at 30 s, capped at 5 minutes.
+func rateLimitBackoff(attempt int) time.Duration {
+	const base = 30 * time.Second
+	const cap_ = 5 * time.Minute
+	d := base
+	for i := 0; i < attempt; i++ {
+		d *= 2
+		if d > cap_ {
+			return cap_
+		}
+	}
+	return d
 }
 
 func (d *Downloader) logDownloadCompletion(filename string, startTime time.Time, downloaded *atomic.Int64, meta downloadLogMeta) {

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -145,8 +145,13 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 		}
 	}
 
-	// Store validation result
-	s.validated.Store(link.DownloadLink, validationErr)
+	// Only cache the validation result when it is worth remembering across calls.
+	// Retryable errors (HTTP 429) are transient — caching them would cause
+	// subsequent GetLink calls to return immediately with a stale error instead
+	// of re-validating the CDN URL after the rate-limit window has cleared.
+	if validationErr == nil || !isRetryableValidationError(validationErr) {
+		s.validated.Store(link.DownloadLink, validationErr)
+	}
 
 	if validationErr == nil {
 		return link, nil
@@ -343,7 +348,7 @@ func (s *Service) getPlacementFile(entry *storage.Entry, filename string) (*stor
 	return placementFile, nil
 }
 
-// validateLink validates a download link by making a HEAD request
+// validateLink validates a download link by making a HEAD request.
 func (s *Service) validateLink(ctx context.Context, link *types.DownloadLink) error {
 	if link == nil {
 		return NewPermanentError(ErrEmptyLink, "empty_link")
@@ -369,16 +374,37 @@ func (s *Service) validateLink(ctx context.Context, link *types.DownloadLink) er
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
 		return nil
+	case http.StatusTooManyRequests:
+		return NewRetryableError(Err429, "429")
+	case http.StatusServiceUnavailable:
+		return NewRetryableError(Err503, "503")
+	case http.StatusUnauthorized:
+		return NewPermanentError(ErrUnauthorized, "401")
+	case http.StatusNotFound:
+		return NewPermanentError(Err404, "404")
+	case http.StatusBadRequest, http.StatusForbidden, http.StatusGone:
+		// Presigned CDN URLs (TorBox, RD, etc.) return 400, 403, or 410 when the
+		// URL has expired. Treat these as refetchable so invalidateAndRefetch is
+		// triggered and a fresh URL is obtained from the debrid API.
+		return NewRefetchableError(ErrLinkExpired, strconv.Itoa(resp.StatusCode))
+	default:
+		errorCode := resp.Header.Get("X-Error")
+		if errorCode == "" {
+			errorCode = strconv.Itoa(resp.StatusCode)
+		}
+		return ErrorCodeToLinkError(errorCode)
 	}
+}
 
-	errorCode := resp.Header.Get("X-Error")
-	if errorCode == "" {
-		errorCode = strconv.Itoa(resp.StatusCode)
-	}
-
-	return ErrorCodeToLinkError(errorCode)
+// isRetryableValidationError returns true when the error should not be cached
+// in the validated map — i.e. it is transient and should be re-checked on the
+// next GetLink call rather than short-circuiting with a stale result.
+func isRetryableValidationError(err error) bool {
+	le := GetLinkError(err)
+	return le != nil && le.ShouldRetry()
 }
 
 // disableLinkAccount handles errors that require disabling an account

--- a/pkg/manager/repair_sweep.go
+++ b/pkg/manager/repair_sweep.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirrobot01/decypharr/internal/customerror"
 	"github.com/sirrobot01/decypharr/pkg/arr"
 	"github.com/sirrobot01/decypharr/pkg/storage"
+	"github.com/sirrobot01/decypharr/pkg/usenet"
 )
 
 // candidate is the unit of work for a sweep. One per entry-folder.
@@ -289,7 +290,10 @@ func (r *Repair) probeNZBFile(ctx context.Context, entry *storage.Entry, name st
 		res.healthy = true
 		return res
 	}
-	if errors.Is(err, customerror.UsenetSegmentMissingError) {
+	if errors.Is(err, usenet.ErrNZBNotFound) {
+		res.broken = true
+		res.reason = "nzb_not_found"
+	} else if errors.Is(err, customerror.UsenetSegmentMissingError) {
 		res.broken = true
 		res.reason = "usenet_segment_missing"
 	} else {

--- a/pkg/manager/stream.go
+++ b/pkg/manager/stream.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirrobot01/decypharr/internal/retry"
 	"github.com/sirrobot01/decypharr/internal/utils"
 	"github.com/sirrobot01/decypharr/pkg/storage"
+	"github.com/sirrobot01/decypharr/pkg/usenet"
 )
 
 const (
@@ -316,7 +317,13 @@ func (m *Manager) streamUsenet(ctx context.Context, entry *storage.Entry, filena
 	}
 
 	// Stream NZB content directly into writer
-	return m.usenet.Stream(ctx, entry.InfoHash, filename, start, end, writer)
+	streamErr := m.usenet.Stream(ctx, entry.InfoHash, filename, start, end, writer)
+	if streamErr != nil && errors.Is(streamErr, usenet.ErrNZBNotFound) {
+		// NZB metadata is permanently gone — flag the entry for the next repair sweep
+		// so Radarr/Sonarr will be notified and can trigger a re-search.
+		m.storage.MarkEntryDirty(entry.Name, config.ProtocolNZB, "nzb_not_found")
+	}
+	return streamErr
 }
 
 func normalizeStreamRange(size, start, end int64) (int64, int64, error) {

--- a/pkg/usenet/storage.go
+++ b/pkg/usenet/storage.go
@@ -1,6 +1,7 @@
 package usenet
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,10 @@ import (
 	"github.com/sirrobot01/decypharr/pkg/storage"
 	"google.golang.org/protobuf/proto"
 )
+
+// ErrNZBNotFound is returned when NZB metadata for an entry cannot be located on disk.
+// It indicates the NZB was never stored or has been deleted, and is a permanent (non-retriable) error.
+var ErrNZBNotFound = errors.New("nzb not found")
 
 const (
 	metaFileExtension = ".meta"
@@ -143,7 +148,7 @@ func (s *NZBStorage) GetNZB(id string) (*storage.NZB, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("nzb not found: %s", id)
+			return nil, fmt.Errorf("%w: %s", ErrNZBNotFound, id)
 		}
 		return nil, fmt.Errorf("failed to read NZB meta file: %w", err)
 	}


### PR DESCRIPTION
## Problem

Two related bugs in `processTorrentDownload` for multi-file torrent batch downloads:

**1 — Partial `GetLink` failure silently skips files (original bug)**

If `GetLink` returns any error for one file in a multi-file batch, the file was
silently dropped with `continue`. The remaining files downloaded, `completeEntry`
was called, and the arr marked the torrent 100% complete. The missing file could
not be re-grabbed as individual releases were uncached on the debrid service.

**2 — HTTP 429 rate-limit causes premature failure and arr item removal**

After fixing bug 1, a `GetLink` 429 now correctly fails the whole job -- but the
entry gets `EntryStateError`, which causes the arr to remove it from queue and
re-grab. Since the re-grab is an individual uncached release, this almost always
fails, leaving the episode permanently missing.

Fixes #315

---

## Fix

### Part 1 — Fail whole job on any `GetLink` error

Replace the silent `continue` with a hard `return`. A partial link failure aborts
the job; the arr keeps the entry in queue and retries.

### Part 2 — Retry on 429 with `pausedDL` backoff

When `GetLink` returns HTTP 429, retry up to `rate_limit_retries` times (default 3)
before failing. Between retries:

- Entry state is set to `pausedDL` -- Sonarr/Radarr see it as **Paused** and hold
  the item without removing it or triggering a re-grab.
- Backoff: 30 s -> 60 s -> 120 s, capped at 5 min.
- After each sleep the link-validation cache is cleared so the next attempt
  re-validates the CDN URL rather than re-using a stale 429 result.

### Part 3 — CDN link expiry during the pause (edge case)

If the debrid CDN presigned URL expires while decypharr is sleeping (e.g. a
previously-obtained URL was already near its TTL), re-validating it returns
HTTP 400 or 403. Previously these were classified as `CategoryPermanent`, making
the error unrecoverable.

Changes in `validateLink`:

| Status | Before | After |
|---|---|---|
| 400 Bad Request | `CategoryPermanent` | `CategoryRefetchable` (expired presigned URL) |
| 403 Forbidden | `CategoryPermanent` | `CategoryRefetchable` (expired presigned URL) |
| 410 Gone | `CategoryPermanent` | `CategoryRefetchable` |
| 429 Too Many Requests | via `ErrorCodeToLinkError` | explicit `CategoryRetryable` |

`CategoryRefetchable` triggers `invalidateAndRefetch`, which evicts the stale CDN
URL from the account cache and fetches a fresh one from the debrid API.

Additionally, `CategoryRetryable` errors are no longer cached in the validated map.
This ensures subsequent `GetLink` calls always re-validate the CDN URL rather than
short-circuiting with a stale 429 result.

---

## New configuration parameter

| Field | Type | Default | Env var |
|---|---|---|---|
| `rate_limit_retries` | int | `3` | `DECYPHARR_RATE_LIMIT_RETRIES` |

```json
{
  rate_limit_retries: 3
}
```

> How many times to retry a `GetLink` call that returns HTTP 429 before failing the
> whole job. Set to `0` to disable retry behaviour and fail immediately on 429.

Documented in `docs/src/content/docs/guides/configuration.md`.

---

## Files changed

- `pkg/manager/downloader.go` -- retry loop + `pausedDL` state + backoff
- `pkg/manager/link/service.go` -- `validateLink` status-code handling; no-cache for retryable errors
- `internal/config/config.go` -- `rate_limit_retries` field + default
- `internal/config/env.go` -- `DECYPHARR_RATE_LIMIT_RETRIES` env override
- `docs/src/content/docs/guides/configuration.md` -- Download Behaviour section + new param