### PR TITLE
fix(alldebrid): retry transient statusCode 7/14 before treating as terminal error

### DIFF
--- a/pkg/debrid/providers/alldebrid/alldebrid.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid.go
@@ -341,19 +341,8 @@ func (ad *AllDebrid) GetTorrent(torrentId string) (*types.Torrent, error) {
 	return t, nil
 }
 
-func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
-	var res TorrentInfoResponse
-
-	resp, err := ad.doRequest("/magnet/status", map[string]string{"id": t.Id}, &res)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
-	}
-
-	data := res.Data.Magnets
+// populateTorrentFromStatus copies an AllDebrid /magnet/status response onto t.
+func (ad *AllDebrid) populateTorrentFromStatus(t *types.Torrent, data magnetInfo) {
 	status := getAlldebridStatus(data.StatusCode)
 	name := data.Filename
 	t.Name = name
@@ -378,16 +367,56 @@ func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
 		}
 		t.Speed = data.DownloadSpeed
 	}
+}
+
+func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
+	var res TorrentInfoResponse
+
+	resp, err := ad.doRequest("/magnet/status", map[string]string{"id": t.Id}, &res)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
+	}
+
+	ad.populateTorrentFromStatus(t, res.Data.Magnets)
 	return nil
 }
 
-func (ad *AllDebrid) CheckStatus(torrent *types.Torrent) (*types.Torrent, error) {
-	for {
-		err := ad.UpdateTorrent(torrent)
+// alldebridRetryableStatusCodes are AllDebrid magnet statusCodes that frequently resolve on
+// their own shortly after first being reported (a temporary stall finding peers, or a transient
+// tracker-contact failure) rather than representing a permanently dead torrent. Unlike a hard
+// failure (e.g. "Deleted on the hoster website"), giving these a few more checks before treating
+// them as terminal avoids deleting torrents that the source has plenty of seeders for.
+//   - 7:  "Not downloaded in 20 min" (download stalled/timed out, often transient)
+//   - 14: "Error while contacting tracker" (transient network/tracker issue)
+var alldebridRetryableStatusCodes = map[int]bool{
+	7:  true,
+	14: true,
+}
 
-		if err != nil || torrent == nil {
+func (ad *AllDebrid) CheckStatus(torrent *types.Torrent) (*types.Torrent, error) {
+	const (
+		maxStatusRetries = 3
+		statusRetryDelay = 2 * time.Minute
+	)
+
+	retries := 0
+	for {
+		var res TorrentInfoResponse
+		resp, err := ad.doRequest("/magnet/status", map[string]string{"id": torrent.Id}, &res)
+		if err != nil {
 			return torrent, err
 		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return torrent, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
+		}
+
+		data := res.Data.Magnets
+		ad.populateTorrentFromStatus(torrent, data)
+
 		switch torrent.Status {
 		case types.TorrentStatusDownloaded:
 			ad.logger.Info().Msgf("Torrent: %s downloaded", torrent.Name)
@@ -398,6 +427,13 @@ func (ad *AllDebrid) CheckStatus(torrent *types.Torrent) (*types.Torrent, error)
 			}
 			return torrent, nil
 		case types.TorrentStatusError:
+			if alldebridRetryableStatusCodes[data.StatusCode] && retries < maxStatusRetries {
+				retries++
+				ad.logger.Warn().Msgf("Torrent: %s reported transient AllDebrid status %d (%s), retrying (%d/%d) in %s",
+					torrent.Name, data.StatusCode, data.Status, retries, maxStatusRetries, statusRetryDelay)
+				time.Sleep(statusRetryDelay)
+				continue
+			}
 			return torrent, fmt.Errorf("torrent: %s has error", torrent.Name)
 		default:
 			return torrent, fmt.Errorf("torrent: %s has error", torrent.Name)


### PR DESCRIPTION
Fixes #335

## What

AllDebrid statusCode `7` ("Not downloaded in 20 min") and `14` ("Error while contacting tracker") were mapped straight to `TorrentStatusError` on the very first status check, with no retry. `CheckStatus()` returned that error immediately, which causes Decypharr to report the download as failed to the Arr app and delete the magnet from AllDebrid.

In practice these two codes are often transient - I observed torrents with plenty of seeders on the source tracker get deleted after a single "no peer" reading, only to complete in seconds when the exact same magnet was re-added to AllDebrid manually moments later.

This is inconsistent with the RealDebrid provider, which treats several in-progress states (`queued`, `magnet_conversion`, `compressing`, `uploading`, `waiting_files_selection`) as retryable rather than terminal. I never saw this issue before switching from RealDebrid to AllDebrid.

## Change

- Extracted the field-population logic shared by `UpdateTorrent` and `CheckStatus` into `populateTorrentFromStatus`, so `CheckStatus` has access to the raw AllDebrid `statusCode` (previously only the mapped `types.TorrentStatus` was available to it).
- `CheckStatus` now retries up to 3 times (2 minute delay between attempts) specifically when the raw status code is `7` or `14`, before falling back to the existing immediate-error behavior.
- All other error codes (`5, 6, 8, 9, 10, 11, 12, 13, 15`) are untouched and remain immediately terminal, since they represent genuinely permanent states (file too big, expired, deleted on hoster, etc).

## Testing

- `go build ./...` passes.
- Built and ran the patched binary against my own AllDebrid account for several hours. On startup alone it caught and successfully retried 4 separate torrents that had been sitting at statusCode 7 - all 4 went on to download normally instead of being deleted.

Open to feedback on the retry count/delay, or on whether code 10 ("download took more than 72h") should get similar treatment - I kept this PR scoped to the two codes I could directly confirm were transient in my own logs.
