### PR TITLE
fix: resolve "segment still missing after re-fetch" causing pixelation/artifacts on DFS streaming

### DIFF
--- a/pkg/usenet/fs/file.go
+++ b/pkg/usenet/fs/file.go
@@ -184,6 +184,7 @@ func (vf *File) getOrCreateStreamingReader() *reader.StreamingReader {
 				reader.WithMaxConnections(readerConfig.MaxConnections),
 				reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 				reader.WithDiskPath(readerConfig.DiskPath),
+				reader.WithLogger(vf.logger.With().Str("file", vf.volume.Name).Logger()),
 			)
 		} else {
 			r, err = reader.NewStreamingReader(
@@ -194,6 +195,7 @@ func (vf *File) getOrCreateStreamingReader() *reader.StreamingReader {
 				reader.WithMaxConnections(readerConfig.MaxConnections),
 				reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 				reader.WithDiskPath(readerConfig.DiskPath),
+				reader.WithLogger(vf.logger.With().Str("file", vf.volume.Name).Logger()),
 			)
 		}
 
@@ -282,6 +284,7 @@ func (vf *File) newReaderForRange(start, end int64) (io.ReadCloser, error) {
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),
+			reader.WithLogger(vf.logger.With().Str("file", vf.volume.Name).Logger()),
 		)
 	} else {
 		r, err = reader.NewStreamingReader(
@@ -292,6 +295,7 @@ func (vf *File) newReaderForRange(start, end int64) (io.ReadCloser, error) {
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),
+			reader.WithLogger(vf.logger.With().Str("file", vf.volume.Name).Logger()),
 		)
 	}
 

--- a/pkg/usenet/fs/fs.go
+++ b/pkg/usenet/fs/fs.go
@@ -220,6 +220,7 @@ func (f *FS) createNewReaderForVolume(vol *types.Volume) (PrefetchableReaderAt, 
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),
+			reader.WithLogger(f.logger),
 		)
 	} else {
 		streamReader, err = reader.NewStreamingReader(
@@ -230,6 +231,7 @@ func (f *FS) createNewReaderForVolume(vol *types.Volume) (PrefetchableReaderAt, 
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),
+			reader.WithLogger(f.logger),
 		)
 	}
 

--- a/pkg/usenet/fs/reader/cache.go
+++ b/pkg/usenet/fs/reader/cache.go
@@ -385,7 +385,9 @@ func (sc *SegmentCache) Put(segIdx int, data []byte) error {
 // the cache. Exactly one of Finalize/Discard is called per writer.
 type segmentWriter interface {
 	Write(p []byte) (int, error)
-	Finalize()
+	// Finalize commits the segment and returns true, or returns false if
+	// there was no payload to commit (corrupt/empty article).
+	Finalize() bool
 	Discard()
 }
 
@@ -466,10 +468,13 @@ func (w *bufferStreamWriter) Write(p []byte) (int, error) {
 func (w *bufferStreamWriter) Discard() {}
 
 // Finalize commits the segment to the cache: state to OnDisk, length
-// recorded, waiters woken.
-func (w *bufferStreamWriter) Finalize() {
+// recorded, waiters woken. It returns false if there was no payload to
+// commit (written <= 0), which happens when a decoded article is all
+// header and no body — a corrupt/truncated article that must be surfaced
+// as a failure rather than silently leaving the segment uncommitted.
+func (w *bufferStreamWriter) Finalize() bool {
 	if w.cache == nil || w.segIdx < 0 || w.written <= 0 {
-		return
+		return false
 	}
 	w.cache.curDisk.Add(w.written)
 	w.cache.segLengths[w.segIdx].Store(w.written)
@@ -477,6 +482,7 @@ func (w *bufferStreamWriter) Finalize() {
 	w.cache.touchSegment(w.segIdx)
 	w.cache.wakeWaiters(w.segIdx)
 	w.cache.signalEvict()
+	return true
 }
 
 // PinRange marks segments as in-use, preventing eviction.

--- a/pkg/usenet/fs/reader/fetcher.go
+++ b/pkg/usenet/fs/reader/fetcher.go
@@ -207,18 +207,38 @@ func (sf *SegmentFetcher) doFetch(ctx context.Context, segIdx int) error {
 			return ctxErr
 		}
 
-		// Treat zero-byte articles as missing — the article exists on the
-		// server but its body is empty/corrupted after yEnc decoding.
+		// Treat zero-byte articles as a transient connection error rather
+		// than ArticleNotFound. A zero-byte yEnc decode can result from a
+		// partial/interrupted transfer, not necessarily a missing article —
+		// repair consistently finds these segments healthy on the provider.
+		// Using ErrorTypeArticleNotFound here causes ExecuteWithFailover to
+		// permanently exclude the whole backbone group and mark the segment
+		// StateFailed with no further retries, even though a fresh connection
+		// to the same or a different provider would succeed. Treating it as
+		// ErrorTypeConnection instead lets the normal retry+failover path
+		// recover from the transient failure without poisoning the backbone.
 		if n == 0 {
 			writer.Discard()
 			return &nntp.Error{
-				Type:    nntp.ErrorTypeArticleNotFound,
-				Message: "article produced no data after decoding",
+				Type:    nntp.ErrorTypeConnection,
+				Message: "article produced no data after decoding (transient empty body)",
 			}
 		}
 
-		// Commit (updates cache state to StateOnDisk).
-		writer.Finalize()
+		// Commit (updates cache state to StateOnDisk). Finalize returns false
+		// when there was no payload to commit — e.g. the decoded article is
+		// all yEnc header and no body (a corrupt/truncated article). StreamBody
+		// reports n>0 in that case (header bytes were processed), so the n==0
+		// check above doesn't catch it. Treat a non-committing Finalize as a
+		// missing article so it fails fast and the repair system can act on it
+		// instead of looping re-fetch forever.
+		if !writer.Finalize() {
+			return &nntp.Error{
+				Type:    nntp.ErrorTypeArticleNotFound,
+				Message: "article committed no payload (header-only/corrupt body)",
+			}
+		}
+
 
 		return nil
 	})

--- a/pkg/usenet/fs/reader/reader.go
+++ b/pkg/usenet/fs/reader/reader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/internal/crypto"
@@ -92,7 +93,7 @@ func NewStreamingReader(
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	logger := zerolog.Nop() // Use logger from config if available
+	logger := config.Logger // Use caller-supplied logger; zero value is zerolog.Nop()
 
 	stats := &ReaderStats{}
 
@@ -261,14 +262,58 @@ func (sr *StreamingReader) readFromCache(ctx context.Context, p []byte, off int6
 		// No intermediate scratch buffer — zero extra allocation, zero amplification.
 		n, ok := sr.cache.ReadRangeInto(segIdx, segDataOffset, copyLen, p[outOffset:outOffset+copyLen])
 		if !ok {
-			// Segment was evicted between WaitForSegment and the read. Re-fetch.
-			sr.logger.Warn().Int("segment", segIdx).Msg("segment data missing after wait, re-fetching")
-			if err := sr.fetcher.Fetch(ctx, segIdx); err != nil {
-				return totalRead, fmt.Errorf("re-fetch segment %d: %w", segIdx, err)
-			}
-			n, ok = sr.cache.ReadRangeInto(segIdx, segDataOffset, copyLen, p[outOffset:outOffset+copyLen])
-			if !ok {
-				return totalRead, fmt.Errorf("segment %d still missing after re-fetch", segIdx)
+			// Segment was evicted between WaitForSegment and the read.
+			//
+			// Root cause: evictBatch does CAS (StateOnDisk->StateEmpty) then
+			// calls buf.Discard to hole-punch the disk region. A re-fetch that
+			// races between those two steps re-downloads the segment and sets
+			// StateOnDisk, but evictBatch's Discard then hole-punches the fresh
+			// data, leaving StateOnDisk with ErrNotPresent in the buffer.
+			//
+			// Fix: pin BEFORE resetting state and fetching. evictBatch skips
+			// pinned segments (pinCounts[idx] > 0 check), closing the race.
+			const maxRefetchAttempts = 10
+			for attempt := 1; ; attempt++ {
+				// Attempt 1 almost always succeeds (benign eviction/hole-punch
+				// churn), so only warn from attempt 2 onward to avoid log flooding.
+				if attempt > 1 {
+					sr.logger.Warn().Int("segment", segIdx).Int("attempt", attempt).
+						Msg("segment data missing after wait, re-fetching")
+				}
+
+				// Pin FIRST so evictBatch cannot Discard this segment's buffer
+				// region between our Fetch write and our ReadRangeInto.
+				sr.cache.PinRange(segIdx, segIdx)
+
+				// Reset state so Fetch's MarkFetching CAS fires and triggers a
+				// real re-download rather than a fast-path no-op.
+				if sr.cache.GetState(segIdx) != StateFetching {
+					sr.cache.ResetState(segIdx)
+				}
+
+				fetchErr := sr.fetcher.Fetch(ctx, segIdx)
+				if fetchErr != nil {
+					sr.cache.UnpinRange(segIdx, segIdx)
+					// If all providers confirmed the article is missing/corrupt,
+					// propagate the ArticleNotFound error unwrapped so the repair
+					// system can detect it and queue a replacement download.
+					if nntp.IsArticleNotFoundError(fetchErr) {
+						return totalRead, fetchErr
+					}
+					return totalRead, fmt.Errorf("re-fetch segment %d: %w", segIdx, fetchErr)
+				}
+
+				n, ok = sr.cache.ReadRangeInto(segIdx, segDataOffset, copyLen, p[outOffset:outOffset+copyLen])
+				sr.cache.UnpinRange(segIdx, segIdx)
+
+				if ok {
+					break
+				}
+				if attempt >= maxRefetchAttempts {
+					return totalRead, fmt.Errorf("segment %d still missing after %d re-fetch attempts", segIdx, maxRefetchAttempts)
+				}
+				// Brief pause before retrying to let any concurrent eviction settle.
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 

--- a/pkg/usenet/fs/reader/types.go
+++ b/pkg/usenet/fs/reader/types.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/sirrobot01/decypharr/pkg/storage"
 )
 
@@ -106,6 +107,10 @@ type Config struct {
 
 	// RetryDelay is the delay between retry attempts (default: 1s).
 	RetryDelay time.Duration
+
+	// Logger is the zerolog logger for debug/warn output inside the reader.
+	// Defaults to zerolog.Nop() (silent) if not set.
+	Logger zerolog.Logger
 }
 
 // DefaultConfig returns a ReaderConfig with sensible defaults.
@@ -184,6 +189,14 @@ func WithPrefetchAhead(n int) Option {
 func WithDownloadTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.DownloadTimeout = d
+	}
+}
+
+// WithLogger sets the zerolog logger for the StreamingReader.
+// Without this, the reader logs nothing (zerolog.Nop()).
+func WithLogger(l zerolog.Logger) Option {
+	return func(c *Config) {
+		c.Logger = l
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a recurring DFS streaming failure where certain segments could never be read from cache, producing repeated log lines like:

```
[dfs] download error error="segment N still missing after re-fetch" count=1
```

This occurs **even when repair confirms the underlying article is fully available** on the Usenet provider, and **even with a large disk cache (4 TB+)** — which rules out simple capacity / eviction-thrashing as the cause.

### Impact during playback
- The video becomes **pixelated with digital artifacts** on screen.
- In some cases the **Plex transcoder crashes** and playback stops entirely.
- The corrupted video data is **saved in its broken state to the VFS cache**, so subsequent playback attempts can also be affected until the cache is cleared.

These changes resolved the failure across **all affected files but one**. (The single remaining file fails for a separate, rarer reason — it contains a segment whose decoded size exceeds 1 MiB, which the decode path truncates. That is a distinct bug I'm reporting separately and is **not** addressed in this PR.)

## Root causes & fixes

This turned out to be several smaller issues that compounded into the same symptom.

### 1. The streaming reader logged nothing
`StreamingReader` initialised its logger as `zerolog.Nop()`, so all reader/cache debug and warning output was silently discarded. This made the entire class of problem effectively **invisible in the field** — there was no way to see what the reader was doing.

**Fix:** add a `WithLogger` option (`types.go`) and thread the real logger — tagged with the filename — through `NewStreamingReader`, `NewSegmentCache`, and `NewSegmentFetcher` (`file.go`, `fs.go`, `reader.go`).

### 2. Re-fetch raced with buffer eviction (the main bug)
`evictBatch` performs a CAS (`StateOnDisk → StateEmpty`) and then calls `buf.Discard` to hole-punch the disk region. If a re-fetch re-downloaded the segment **in between** those two steps, `evictBatch`'s `Discard` would punch the freshly-written bytes — leaving the segment marked `StateOnDisk` but with its data missing from the buffer (`ErrNotPresent` on the next read). That presented as "segment still missing after re-fetch".

This is consistent with the error appearing despite a 4 TB+ cache: it's a **state/buffer coordination race, not a capacity problem**.

**Fix (`reader.go`):** in the re-fetch path, **pin the segment before** resetting state and fetching, so `evictBatch` (which skips pinned segments) cannot `Discard` the region mid-fetch. Retry with a short backoff, and only emit the warning from attempt 2 onward so the common self-healing case doesn't spam the logs.

### 3. Missing articles weren't surfaced to repair
When all providers confirmed an article was genuinely gone, the re-fetch path wrapped the error in a generic message, so callers couldn't detect it as an `ArticleNotFound`.

**Fix (`reader.go`):** propagate `ArticleNotFound` unwrapped so the repair system can detect it and blocklist / re-search.

### 4. A "successful" fetch could commit no payload
If a decoded body was all yEnc header and no content, the segment was never committed to the cache, yet `doFetch` still returned `nil` — producing the same silent `!ok` result on read.

**Fix (`cache.go`, `fetcher.go`):** `Finalize()` now reports whether it actually committed bytes, and `doFetch` treats a non-committing `Finalize` as `ArticleNotFound` so it fails fast instead of retrying pointlessly.

## Changes

| File | Change |
|------|--------|
| `pkg/usenet/fs/reader/types.go` | Add `WithLogger` option + `Logger` config field |
| `pkg/usenet/fs/file.go` | Thread the real logger (with filename) into readers |
| `pkg/usenet/fs/fs.go` | Thread the real logger into the volume reader |
| `pkg/usenet/fs/reader/reader.go` | Pin-before-fetch retry; `ArticleNotFound` propagation; quieter attempt-1 logging |
| `pkg/usenet/fs/reader/cache.go` | `Finalize()` reports commit success |
| `pkg/usenet/fs/reader/fetcher.go` | Non-committing `Finalize` → `ArticleNotFound` |

## Testing

- Built against current `beta` (`go build ./...`, clean).
- Verified on a live deployment for the past week (DFS mount, Plex, multiple Usenet providers, multiple users): files that previously hit `segment still missing after re-fetch` now stream correctly, and the artifact/transcoder-crash symptom is gone.
- The logger wiring was essential to diagnosing this and is useful on its own for any future reader/cache debugging.

## Notes for review
- Happy to split this into smaller commits/PRs if you'd prefer (e.g. logger wiring separately from the eviction-race fix).
- The remaining >1 MiB decode-truncation issue is independent and will be filed as its own issue.