### PR TITLE
Fix: authentication being disabled after saving settings

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -523,6 +523,11 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	// Preserve fields that shouldn't be overwritten by frontend
 	currentConfig := config.Get()
 	newConfig.Auth = currentConfig.GetAuth()
+	// The frontend config form doesn't include use_auth or enable_webdav_auth,
+	// so they would be zero-valued (false) in the decoded payload. Preserve
+	// them from the live config so auth isn't silently disabled on every save.
+	newConfig.UseAuth = currentConfig.UseAuth
+	newConfig.EnableWebdavAuth = currentConfig.EnableWebdavAuth
 
 	// Filter out empty or incomplete arrs
 	validArrs := make([]config.Arr, 0, len(newConfig.Arrs))


### PR DESCRIPTION
In the binary build, if you set up a username and password via the Auth tab, click "Update authentication" and then later change any setting and hit Save Configuration, authentication would be silently disabled on the next restart. You'd find yourself having to re-enter your auth credentials every single time you saved a config change.

**What was actually happening?**

The credentials themselves (stored in auth.json) were never lost. The problem was the flag that tells the app to actually enforce authentication (`use_auth`) was being reset to false on every config save.

The settings form doesn't include `use_auth` or `enable_webdav_auth` in the data it sends to the server when you hit Save Configuration. So when the server received that data and decoded it into a fresh config struct, both flags defaulted to false. That false value then got written to config.json, and on the next restart the app saw auth was disabled and stopped enforcing it.

`handleUpdateConfig` already had logic to preserve the auth credentials from the live config before saving, but it wasn't doing the same for the flags that control whether auth is enforced at all.

**The fix**

Two extra lines in `handleUpdateConfig` in `pkg/server/api.go`, right alongside the existing credentials preservation:

```go
newConfig.UseAuth = currentConfig.UseAuth
newConfig.EnableWebdavAuth = currentConfig.EnableWebdavAuth
```

**How to test**

1. Set up authentication via Settings → Auth → Update Authentication
2. Go to any other settings tab, change something, hit Save Configuration
3. Wait for the restart
4. Confirm you are still logged in and authentication credentials are preserved.
5. Repeat a few times — credentials should survive every save