### PR TITLE
fix(dfs): skip internal metadata in directory listings

### DIFF
--- a/pkg/manager/entry.go
+++ b/pkg/manager/entry.go
@@ -208,6 +208,9 @@ func (m *Manager) getEntryChildren(group string) (*FileInfo, []FileInfo) {
 		var infos []FileInfo
 		seen := make(map[string]struct{})
 		err := m.storage.ForEachMeta(func(meta *storage.EntryMetaInfo) error {
+			if !isListableEntryMeta(meta) {
+				return nil
+			}
 			if _, ok := seen[meta.Name]; ok {
 				return nil
 			}
@@ -232,6 +235,9 @@ func (m *Manager) getEntryChildren(group string) (*FileInfo, []FileInfo) {
 		var infos []FileInfo
 		seen := make(map[string]struct{})
 		err := m.storage.ForEachMeta(func(meta *storage.EntryMetaInfo) error {
+			if !isListableEntryMeta(meta) {
+				return nil
+			}
 			if meta.Protocol == "torrent" {
 				if _, ok := seen[meta.Name]; ok {
 					return nil
@@ -258,6 +264,9 @@ func (m *Manager) getEntryChildren(group string) (*FileInfo, []FileInfo) {
 		var infos []FileInfo
 		seen := make(map[string]struct{})
 		err := m.storage.ForEachMeta(func(meta *storage.EntryMetaInfo) error {
+			if !isListableEntryMeta(meta) {
+				return nil
+			}
 			if meta.Protocol == "nzb" {
 				if _, ok := seen[meta.Name]; ok {
 					return nil
@@ -284,6 +293,9 @@ func (m *Manager) getEntryChildren(group string) (*FileInfo, []FileInfo) {
 		var infos []FileInfo
 		seen := make(map[string]struct{})
 		err := m.storage.ForEachMeta(func(meta *storage.EntryMetaInfo) error {
+			if !isListableEntryMeta(meta) {
+				return nil
+			}
 			if meta.Bad {
 				if _, ok := seen[meta.Name]; ok {
 					return nil
@@ -316,6 +328,9 @@ func (m *Manager) getEntryChildren(group string) (*FileInfo, []FileInfo) {
 			var infos []FileInfo
 			seen := make(map[string]struct{})
 			err := m.storage.ForEachMeta(func(meta *storage.EntryMetaInfo) error {
+				if !isListableEntryMeta(meta) {
+					return nil
+				}
 				if meta.Provider == group {
 					if _, ok := seen[meta.Name]; ok {
 						return nil
@@ -376,6 +391,16 @@ func (m *Manager) getTorrentChildren(name string) (*FileInfo, []FileInfo) {
 		isDir:   true,
 	}
 	return currentDir, infos
+}
+
+func isListableEntryMeta(meta *storage.EntryMetaInfo) bool {
+	if meta == nil || meta.Name == "" || meta.Name == "." || meta.Name == ".." ||
+		strings.HasPrefix(meta.InfoHash, "__") ||
+		strings.Contains(meta.Name, "/") ||
+		strings.ContainsRune(meta.Name, 0) {
+		return false
+	}
+	return true
 }
 
 func (m *Manager) RemoveEntry(entry *FileInfo) error {

--- a/pkg/manager/entry_test.go
+++ b/pkg/manager/entry_test.go
@@ -1,0 +1,59 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/sirrobot01/decypharr/pkg/storage"
+)
+
+func TestIsListableEntryMetaSkipsInternalAndInvalidNames(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *storage.EntryMetaInfo
+		want bool
+	}{
+		{
+			name: "valid entry",
+			meta: &storage.EntryMetaInfo{InfoHash: "abc123", Name: "Example"},
+			want: true,
+		},
+		{
+			name: "migration status",
+			meta: &storage.EntryMetaInfo{InfoHash: "__migration_status__", Name: ""},
+			want: false,
+		},
+		{
+			name: "empty name",
+			meta: &storage.EntryMetaInfo{InfoHash: "abc123", Name: ""},
+			want: false,
+		},
+		{
+			name: "dot name",
+			meta: &storage.EntryMetaInfo{InfoHash: "abc123", Name: "."},
+			want: false,
+		},
+		{
+			name: "slash name",
+			meta: &storage.EntryMetaInfo{InfoHash: "abc123", Name: "bad/name"},
+			want: false,
+		},
+		{
+			name: "nul name",
+			meta: &storage.EntryMetaInfo{InfoHash: "abc123", Name: "bad\x00name"},
+			want: false,
+		},
+		{
+			name: "nil meta",
+			meta: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isListableEntryMeta(tt.meta); got != tt.want {
+				t.Fatalf("isListableEntryMeta() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📌 Description

- Fix DFS directory listings returning `Input/output error` when internal storage metadata records are present.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

- Filter non-listable internal metadata records out of DFS entry listings.
- Prevent records like `__migration_status__` with empty names from being emitted as FUSE directory entries.
- Add unit coverage for internal keys and invalid entry names.

---

## Testing

- [x] Tested locally

Steps:

1. Ran `go test ./pkg/manager ./pkg/mount/dfs/vfs`.
2. Built and deployed a test image with this fix.
3. Verified `ls`, Python `os.listdir`, and raw `getdents64` on `/mnt/remote/realdebrid/__all__/` complete without I/O errors.

---

## Risks / Notes

- Low risk: this only filters metadata records that cannot be valid filesystem entries.
- Does not remove or alter the internal migration status record.
- Existing media entries with valid names remain listable.

---

## Screenshots (if applicable)

N/A

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct