### PR TITLE
fix(logging): stop spamming the debug log with routine HTTP requests

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -175,7 +175,14 @@ func (c *Client) Get(url string) (*http.Response, error) {
 type zerologAdapter struct{ log zerolog.Logger }
 
 func (z zerologAdapter) Printf(format string, args ...interface{}) {
-	z.log.Debug().Msgf(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	// retryablehttp logs "[DEBUG] METHOD URL" for every single request
+	// attempt; suppress those and keep only retry and error events,
+	// which is what wiring this logger up was meant to surface.
+	if strings.HasPrefix(msg, "[DEBUG] ") && !strings.Contains(msg, "retrying in") {
+		return
+	}
+	z.log.Debug().Msg(msg)
 }
 
 // retryAfterBackoff extends DefaultBackoff with Retry-After header support.


### PR DESCRIPTION
Since #329 wired up the retry library's logger, the debug logs have been getting pretty overwhelmed. With the Arr queue polling every 10s and debrid refreshing every 15s, that's hundreds of routine `[DEBUG] GET ...` lines an hour, which drowns out the actual useful info.

This PR filters out those standard per-request announcements in the adapter, but keeps the valuable retry/429 visibility that #329 was originally aiming for.

What's happening now:

* Silenced: routine requests (e.g., `[DEBUG] GET url`).
* Kept: retries (e.g., `[DEBUG] GET url: retrying in 2s (4 left)`) and failures (`[ERR] ...`).

There are no functional changes here — requests, retries, and backoff behavior all work exactly as before. Just much cleaner logs!