### PR TITLE
feat(repair): add optional stop schedule for repair sweeps

### DIFF
--- a/docs/src/content/docs/guides/repair.mdx
+++ b/docs/src/content/docs/guides/repair.mdx
@@ -56,7 +56,8 @@ You can force a recheck on any one entry from the Browse UI or the API. This wor
     "auto_repair": true,
     "skip_nzb_repair": false,
     "notify_on_complete": false,
-    "nntp_connection_percent": 20
+    "nntp_connection_percent": 20,
+    "stop_schedule": "06:00"
   }
 }
 ```
@@ -74,6 +75,32 @@ You can force a recheck on any one entry from the Browse UI or the API. This wor
 | `skip_nzb_repair`         | Skip NZB / Usenet entries during scheduled sweeps.                                      | `false` |
 | `notify_on_complete`      | Send a notification when a sweep finishes.                                               | `false`     |
 | `nntp_connection_percent` | Percentage of NNTP connections the probe is allowed to use. Avoids starving downloads.   | `20`        |
+| `stop_schedule`           | Optional cron expression, clock time, or interval. If a repair sweep is still running when this fires, it's stopped early. Leave empty to always run to completion. | — |
+
+### Stop schedule
+
+`stop_schedule` is useful when a repair sweep needs to finish (or get out of the way) before something else happens — for example, before your overnight maintenance window ends, or before peak-usage hours when probes would compete for bandwidth.
+
+- The repair sweep is cancelled at the next firing of `stop_schedule`, mid-probe if necessary. Entries not yet probed are left as they were before this repair sweep (their existing health and `next_check_due_at` are untouched, so they're picked up again on the next scheduled run).
+- The run is recorded as `completed` (not `cancelled`), with `cancel_reason` noting it was stopped by schedule.
+- What happens to entries this repair sweep *did* manage to probe and found broken is controlled by `auto_repair`, same as any other repair sweep:
+  - `auto_repair: true` repairs them via the normal Arr delete + re-search flow.
+  - `auto_repair: false` leaves them recorded as broken without triggering Arr repair.
+
+#### Multi-day coverage
+
+Each repair sweep probes due entries **oldest-checked-first** (never-checked entries first, then least-recently-checked, ...). Probing an entry updates its `last_checked_at` immediately, which moves it to the back of the queue for future repair sweeps.
+
+This means a repair sweep scheduled daily with a `stop_schedule` (e.g. `schedule: "0 0 * * *"`, `stop_schedule: "0 9 * * *"`) makes guaranteed forward progress across days, as long as `recheck_interval` is comfortably longer than the time it takes to cycle through the whole library:
+
+- Day 1, 00:00–09:00: probes the oldest N due entries (or however many fit in 9 hours), marking each one's `last_checked_at` as it finishes.
+- Day 1, 09:00: `stop_schedule` fires, the repair sweep stops. The remaining entries are untouched and stay oldest in the queue.
+- Day 2, 00:00: the next repair sweep's `due` set excludes everything probed on day 1 (their `last_checked_at` is now within `recheck_interval`), so it continues with the next-oldest N.
+- This repeats until the whole library has been probed within one `recheck_interval` window, then the cycle restarts from the oldest again.
+
+If a full repair sweep would take 2 days at 9 hours/day but `recheck_interval` is `168h` (1 week), this comfortably completes a full pass well before entries become due again. If `recheck_interval` is shorter than the time a full cycle actually takes, some entries may go stale before they're re-probed — increase `recheck_interval`, the daily window, or `workers` to compensate.
+
+
 
 ### Strategies
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,12 +201,21 @@ type RepairConfig struct {
 	Arrs                  []string     `json:"arrs,omitempty"`
 	AutoRepair            bool         `json:"auto_repair,omitempty"`
 	SkipNZBRepair         bool         `json:"skip_nzb_repair,omitempty"`
+
+	// StopSchedule, when set, stops an in-progress repair sweep at this time/interval
+	// (same formats as Schedule: clock time, cron expression, or duration).
+	// A repair sweep still running when StopSchedule fires is cancelled before it
+	// finishes enumerating/probing every candidate. Empty disables the stop
+	// schedule entirely - the repair sweep always runs to completion. When a stop
+	// fires mid-repair-sweep, AutoRepair decides what happens to whatever was
+	// already found broken: repaired if true, left alone if false.
+	StopSchedule string `json:"stop_schedule,omitempty"`
 }
 
 func (r RepairConfig) IsZero() bool {
 	return !r.Enabled && r.Source == "" && r.Schedule == "" && r.Workers == 0 &&
 		r.NNTPConnectionPercent == 0 && r.Strategy == "" && r.RecheckInterval == "" && len(r.Arrs) == 0 &&
-		!r.AutoRepair && !r.SkipNZBRepair
+		!r.AutoRepair && !r.SkipNZBRepair && r.StopSchedule == ""
 }
 
 type Config struct {

--- a/pkg/manager/repair.go
+++ b/pkg/manager/repair.go
@@ -49,14 +49,18 @@ type ClearRepairStateResult struct {
 }
 
 const (
-	repairSchedulerTag    = "repair-sweep"
-	repairDefaultWorkers  = 5
-	repairDefaultRecheck  = 7 * 24 * time.Hour
-	repairHistoryRetained = 100
+	repairSchedulerTag     = "repair-sweep"
+	repairStopSchedulerTag = "repair-sweep-stop"
+	repairDefaultWorkers   = 5
+	repairDefaultRecheck   = 7 * 24 * time.Hour
+	repairHistoryRetained  = 100
 	// At most this many files probed concurrently within a single entry. The
 	// outer worker count comes from cfg.Repair.Workers.
 	repairFilesPerEntry    = 2
 	repairStopDrainTimeout = 30 * time.Second
+	// repairStopFinalRepairTimeout bounds the Arr delete + re-search pass run
+	// when StopSchedule fires and auto-repair is enabled.
+	repairStopFinalRepairTimeout = 5 * time.Minute
 )
 
 // Repair is the health-check / auto-repair service. One instance per Manager.
@@ -65,12 +69,14 @@ type Repair struct {
 	scheduler gocron.Scheduler
 	logger    zerolog.Logger
 
-	mu          sync.Mutex
-	parentCtx   context.Context
-	activeRunID string
-	cancelRun   context.CancelFunc
-	scheduled   bool
-	runWG       sync.WaitGroup
+	mu             sync.Mutex
+	parentCtx      context.Context
+	activeRunID    string
+	cancelRun      context.CancelFunc
+	scheduled      bool
+	stopScheduled  bool
+	activeStopFunc func() // called by the stop job for the active run
+	runWG          sync.WaitGroup
 }
 
 // NewRepair builds the repair service for the given manager. Call
@@ -179,6 +185,25 @@ func (r *Repair) Start(ctx context.Context) error {
 	}
 	r.scheduled = true
 	r.logger.Info().Str("schedule", cfg.Schedule).Msg("Repair sweep scheduled")
+
+	r.scheduler.RemoveByTags(repairStopSchedulerTag)
+	r.stopScheduled = false
+	if stopSchedule := strings.TrimSpace(cfg.StopSchedule); stopSchedule != "" {
+		stopJD, err := utils.ConvertToJobDef(stopSchedule)
+		if err != nil {
+			return fmt.Errorf("invalid repair stop schedule %q: %w", stopSchedule, err)
+		}
+		if _, err := r.scheduler.NewJob(stopJD,
+			gocron.NewTask(func() {
+				r.stopActiveRepairSweep()
+			}),
+			gocron.WithTags(repairStopSchedulerTag),
+		); err != nil {
+			return fmt.Errorf("failed to register repair stop schedule: %w", err)
+		}
+		r.stopScheduled = true
+		r.logger.Info().Str("stop_schedule", stopSchedule).Msg("Repair sweep stop schedule registered")
+	}
 	return nil
 }
 
@@ -190,9 +215,14 @@ func (r *Repair) Stop() {
 	cancel := r.cancelRun
 	r.cancelRun = nil
 	r.activeRunID = ""
+	r.activeStopFunc = nil
 	if r.scheduled {
 		r.scheduler.RemoveByTags(repairSchedulerTag)
 		r.scheduled = false
+	}
+	if r.stopScheduled {
+		r.scheduler.RemoveByTags(repairStopSchedulerTag)
+		r.stopScheduled = false
 	}
 	r.mu.Unlock()
 	if cancel != nil {
@@ -273,6 +303,27 @@ func (r *Repair) StopRun() error {
 	r.logger.Info().Str("run_id", id).Msg("Cancelling repair run")
 	cancel()
 	return nil
+}
+
+// stopActiveRepairSweep is invoked by the StopSchedule job. Unlike StopRun, this is
+// not a user-initiated abort: the repair sweep is marked completed (not cancelled),
+// and whether whatever was found broken up to this point gets repaired is
+// decided by AutoRepair. With no active repair sweep this is a no-op.
+func (r *Repair) stopActiveRepairSweep() {
+	r.mu.Lock()
+	cancel := r.cancelRun
+	id := r.activeRunID
+	stopFunc := r.activeStopFunc
+	r.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+
+	r.logger.Info().Str("run_id", id).Msg("Repair sweep stop schedule fired; stopping repair sweep")
+	if stopFunc != nil {
+		stopFunc()
+	}
+	cancel()
 }
 
 // Status reports the current repair state for the API.
@@ -395,6 +446,7 @@ func (r *Repair) runSweep(trigger storage.RepairRunTrigger, opts RepairRunOption
 	}
 
 	runCtx, cancel := context.WithCancel(r.parentCtx)
+	stopState := &repairStopState{}
 	sourceParts := []string{string(cfg.Source)}
 	if opts.IgnoreLastChecked {
 		sourceParts = append(sourceParts, "ignore-last-checked")
@@ -422,12 +474,14 @@ func (r *Repair) runSweep(trigger storage.RepairRunTrigger, opts RepairRunOption
 	}
 	r.activeRunID = run.ID
 	r.cancelRun = cancel
+	r.activeStopFunc = stopState.set
 	r.mu.Unlock()
 
 	if err := r.manager.storage.SaveRepairRun(run); err != nil {
 		r.mu.Lock()
 		r.activeRunID = ""
 		r.cancelRun = nil
+		r.activeStopFunc = nil
 		r.mu.Unlock()
 		cancel()
 		return "", fmt.Errorf("failed to persist repair run: %w", err)
@@ -439,11 +493,12 @@ func (r *Repair) runSweep(trigger storage.RepairRunTrigger, opts RepairRunOption
 			if r.activeRunID == run.ID {
 				r.activeRunID = ""
 				r.cancelRun = nil
+				r.activeStopFunc = nil
 			}
 			r.mu.Unlock()
 			cancel()
 		}()
-		r.executeSweep(runCtx, run, opts)
+		r.executeSweep(runCtx, run, opts, stopState)
 	})
 
 	r.logger.Info().Str("run_id", run.ID).Str("trigger", string(trigger)).Msg("Repair sweep started")
@@ -510,6 +565,27 @@ func discordContextFor(run *storage.RepairRun) string {
 		run.StartedAt.Format(dateFmt), run.CompletedAt.Format(dateFmt),
 		run.Stats.Probed, run.Stats.Broken, run.Stats.Repaired,
 	)
+}
+
+// repairStopState communicates a StopSchedule-triggered stop from
+// stopActiveRepairSweep (called on the scheduler goroutine) into the running
+// repair sweep. set is called at most once; get is read after the probing context
+// is observed as cancelled.
+type repairStopState struct {
+	mu      sync.Mutex
+	stopped bool
+}
+
+func (s *repairStopState) set() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopped = true
+}
+
+func (s *repairStopState) get() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopped
 }
 
 func (r *Repair) saveRun(run *storage.RepairRun) {

--- a/pkg/manager/repair_sweep.go
+++ b/pkg/manager/repair_sweep.go
@@ -83,15 +83,24 @@ type fileResult struct {
 }
 
 // executeSweep is the body of a sweep: enumerate, filter due, probe, repair.
-func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts RepairRunOptions) {
+func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts RepairRunOptions, stopState *repairStopState) {
 	cfg := r.cfg()
 	log := r.logger.With().Str("run_id", run.ID).Logger()
+
+	// Resolve auto-repair once: when off, the repair sweep is a pure health check —
+	// it probes and records broken state but attempts no debrid re-insert and
+	// no Arr delete/re-search. This also decides what happens to whatever was
+	// found broken so far if a StopSchedule cuts the repair sweep short.
+	autoRepair := cfg.AutoRepair
+	if opts.AutoRepair != nil {
+		autoRepair = *opts.AutoRepair
+	}
 
 	log.Info().Str("source", string(cfg.Source)).Msg("Sweep: selecting candidates")
 	candidates, err := r.enumerateCandidates(ctx, cfg)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			r.finalizeRun(run, storage.RepairRunCancelled, "", "context cancelled during selection")
+			r.finishCancelledRepairSweep(ctx, run, stopState, autoRepair, "context cancelled during selection", nil)
 			return
 		}
 		log.Error().Err(err).Msg("Sweep: enumeration failed")
@@ -99,7 +108,7 @@ func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts 
 		return
 	}
 	if ctx.Err() != nil {
-		r.finalizeRun(run, storage.RepairRunCancelled, "", "context cancelled after selection")
+		r.finishCancelledRepairSweep(ctx, run, stopState, autoRepair, "context cancelled after selection", nil)
 		return
 	}
 
@@ -112,24 +121,27 @@ func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts 
 	run.Stats.Candidates = len(due)
 	run.Stats.SkippedFresh = skipped
 
-	// Resolve auto-repair once: when off, the sweep is a pure health check —
-	// it probes and records broken state but attempts no debrid re-insert and
-	// no Arr delete/re-search.
-	autoRepair := cfg.AutoRepair
-	if opts.AutoRepair != nil {
-		autoRepair = *opts.AutoRepair
-	}
+	// Order candidates oldest-checked-first (never-checked entries sort
+	// first, since their LastCheckedAt is the zero time). This is what makes
+	// a StopSchedule-truncated repair sweep make guaranteed forward progress: any
+	// entry probed today moves to the back of the queue (its LastCheckedAt
+	// becomes "now"), so tomorrow's truncated repair sweep naturally picks up where
+	// today's left off instead of re-rolling a random subset of `due`.
+	//
+	// This slice also doubles as the candidate list considered by this run,
+	// used to scope a stop-schedule repair pass.
+	names := r.orderCandidatesByLastChecked(due)
 
 	run.Stage = storage.RepairStageProbing
 	r.saveRun(run)
 	log.Info().Int("due", len(due)).Int("skipped_fresh", skipped).Str("protocol", protocolScope).Bool("auto_repair", autoRepair).Msg("Sweep: probing")
 
 	heal := newHealCache()
-	err = r.probeAndHealCandidates(ctx, run, due, heal, opts, autoRepair)
+	err = r.probeAndHealCandidates(ctx, run, due, names, heal, opts, autoRepair)
 	due = nil
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			r.finalizeRun(run, storage.RepairRunCancelled, "", "context cancelled during probing")
+			r.finishCancelledRepairSweep(ctx, run, stopState, autoRepair, "context cancelled during probing", names)
 			return
 		}
 		log.Error().Err(err).Msg("Sweep: probing failed")
@@ -137,7 +149,7 @@ func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts 
 		return
 	}
 	if ctx.Err() != nil {
-		r.finalizeRun(run, storage.RepairRunCancelled, "", "context cancelled after probing")
+		r.finishCancelledRepairSweep(ctx, run, stopState, autoRepair, "context cancelled after probing", names)
 		return
 	}
 
@@ -151,16 +163,76 @@ func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts 
 		Msg("Sweep: completed")
 }
 
+// finishCancelledRepairSweep is reached whenever the repair sweep's context is cancelled
+// (StopRun, StopSchedule, or process shutdown). When the cancellation came
+// from a StopSchedule firing, the run is finalized as completed (not
+// cancelled) and, when autoRepair is on, a final repair pass runs over
+// whatever this repair sweep found broken among the candidates it considered
+// (names). When autoRepair is off, nothing further happens to those entries.
+//
+// A user-initiated StopRun already wrote RepairRunCancelled to storage before
+// calling cancel; finalizeRun preserves that status regardless of what's
+// passed here, so the StopRun path is unaffected.
+func (r *Repair) finishCancelledRepairSweep(ctx context.Context, run *storage.RepairRun, stopState *repairStopState, autoRepair bool, reason string, names []string) {
+	stopped := stopState != nil && stopState.get()
+	if !stopped {
+		r.finalizeRun(run, storage.RepairRunCancelled, "", reason)
+		return
+	}
+
+	log := r.logger.With().Str("run_id", run.ID).Logger()
+	log.Info().Bool("auto_repair", autoRepair).Msg("Repair sweep: stop schedule fired; finishing run")
+
+	if autoRepair && len(names) > 0 {
+		// Use a fresh, un-cancelled context for the final repair pass: the
+		// probe pass was cut short, but the repair pass over what's already
+		// known-broken is a short, bounded set of Arr calls and should be
+		// allowed to complete. Bound it so a misbehaving Arr can't hang.
+		repairCtx, cancel := context.WithTimeout(detachedRepairContext(ctx, r.parentCtx), repairStopFinalRepairTimeout)
+		defer cancel()
+
+		healths, _ := r.collectBrokenHealths(names, true)
+		if healths.Size() > 0 {
+			run.Stage = storage.RepairStageRepairing
+			r.saveRun(run)
+			r.repairBroken(repairCtx, run, healths)
+		}
+	}
+
+	run.CancelReason = ""
+	r.finalizeRun(run, storage.RepairRunCompleted, "", "stopped by schedule: "+reason)
+}
+
+// detachedRepairContext returns a context that is not already cancelled, for
+// use by the post-stop repair pass. Falls back to the repair service's parent
+// context (or background) when the run's own context has already been
+// cancelled.
+func detachedRepairContext(runCtx, parentCtx context.Context) context.Context {
+	if runCtx.Err() == nil {
+		return runCtx
+	}
+	if parentCtx != nil {
+		return parentCtx
+	}
+	return context.Background()
+}
+
 // probeAndHealCandidates fans out across candidates with cfg.Repair.Workers
 // concurrency. Each entry then probes its own files internally with at most
 // repairFilesPerEntry concurrency, so total file probes in flight = workers × 2.
+//
+// names gives the iteration order (see orderCandidatesByLastChecked):
+// g.Go is called in this order, so with N workers the oldest-checked N
+// candidates start first. If the run is cut short by a StopSchedule, the
+// candidates that didn't get a chance to start remain oldest-first for the
+// next repair sweep.
 //
 // Healing is folded into the per-entry pass: probeEntry runs auto-heal (debrid
 // re-insert) inline, and when an entry is still broken afterwards this kicks
 // off the Arr delete/blocklist/re-search for that one entry — so there's no
 // separate end-of-run repair pass holding every health in memory. All healing
 // is gated on autoRepair.
-func (r *Repair) probeAndHealCandidates(ctx context.Context, run *storage.RepairRun, candidates map[string]*candidate, heal *healCache, opts RepairRunOptions, autoRepair bool) error {
+func (r *Repair) probeAndHealCandidates(ctx context.Context, run *storage.RepairRun, candidates map[string]*candidate, names []string, heal *healCache, opts RepairRunOptions, autoRepair bool) error {
 	// run.Stats has plain int fields, so a single mutex guards every mutation
 	// and the saveRun that follows it.
 	var runMu sync.Mutex
@@ -168,11 +240,16 @@ func (r *Repair) probeAndHealCandidates(ctx context.Context, run *storage.Repair
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(max(1, r.workers()))
 
-	for name, c := range candidates {
+	for _, name := range names {
+		c := candidates[name]
+		if c == nil {
+			continue
+		}
 		g.Go(func() error {
 			if gctx.Err() != nil {
 				return gctx.Err()
 			}
+
 			h := r.probeEntry(gctx, run.ID, c, heal, opts, autoRepair)
 			if h == nil {
 				// Entry vanished or had no files between enumeration and probe;
@@ -936,6 +1013,41 @@ func (r *Repair) filterDueCandidates(in map[string]*candidate, ignoreLastChecked
 	return out, skipped
 }
 
+// orderCandidatesByLastChecked returns the names of `due` sorted by
+// EntryHealth.LastCheckedAt ascending - entries never checked (zero time)
+// sort first, then least-recently-checked, etc. Ties (e.g. multiple
+// never-checked entries) break on name for a stable, deterministic order
+// across runs.
+//
+// This ordering is what lets a StopSchedule-truncated repair sweep make guaranteed
+// forward progress across days: probing an entry updates its LastCheckedAt
+// immediately, so it sorts to the back of tomorrow's queue.
+func (r *Repair) orderCandidatesByLastChecked(due map[string]*candidate) []string {
+	type ordered struct {
+		name          string
+		lastCheckedAt time.Time
+	}
+	items := make([]ordered, 0, len(due))
+	for name := range due {
+		var lastCheckedAt time.Time
+		if h, _ := r.manager.storage.GetEntryHealth(name); h != nil {
+			lastCheckedAt = h.LastCheckedAt
+		}
+		items = append(items, ordered{name: name, lastCheckedAt: lastCheckedAt})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if !items[i].lastCheckedAt.Equal(items[j].lastCheckedAt) {
+			return items[i].lastCheckedAt.Before(items[j].lastCheckedAt)
+		}
+		return items[i].name < items[j].name
+	})
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.name
+	}
+	return out
+}
+
 // === Manual rechecks (webhooks + API) ===
 
 func (r *Repair) collectBrokenHealths(names []string, requireArrFile bool) (*xsync.Map[string, *storage.EntryHealth], int) {
@@ -1352,7 +1464,11 @@ func (r *Repair) executeRecheckMedia(ctx context.Context, run *storage.RepairRun
 	r.saveRun(run)
 
 	heal := newHealCache()
-	err := r.probeAndHealCandidates(ctx, run, candidates, heal, RepairRunOptions{}, fix)
+	mediaNames := make([]string, 0, len(candidates))
+	for name := range candidates {
+		mediaNames = append(mediaNames, name)
+	}
+	err := r.probeAndHealCandidates(ctx, run, candidates, mediaNames, heal, RepairRunOptions{}, fix)
 	candidates = nil
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/pkg/server/assets/js/config.js
+++ b/pkg/server/assets/js/config.js
@@ -163,6 +163,7 @@ class ConfigManager {
         if ($('repair.workers')) $('repair.workers').value = repair.workers || 5;
         if ($('repair.nntp_connection_percent')) $('repair.nntp_connection_percent').value = repair.nntp_connection_percent || 20;
         if ($('repair.strategy')) $('repair.strategy').value = repair.strategy || 'per_entry';
+        if ($('repair.stop_schedule')) $('repair.stop_schedule').value = repair.stop_schedule || '';
         if ($('repair.auto_repair')) $('repair.auto_repair').checked = !!repair.auto_repair;
         if ($('repair.skip_nzb_repair')) $('repair.skip_nzb_repair').checked = !!repair.skip_nzb_repair;
     }
@@ -181,6 +182,7 @@ class ConfigManager {
             workers: parseInt($('repair.workers')?.value, 10) || 0,
             nntp_connection_percent: parseInt($('repair.nntp_connection_percent')?.value, 10) || 0,
             strategy: $('repair.strategy')?.value || 'per_entry',
+            stop_schedule: $('repair.stop_schedule')?.value.trim() || '',
             auto_repair: $('repair.auto_repair')?.checked || false,
             skip_nzb_repair: $('repair.skip_nzb_repair')?.checked || false,
             arrs,

--- a/pkg/server/templates/config.html
+++ b/pkg/server/templates/config.html
@@ -1420,6 +1420,15 @@
                                     <option value="per_file">Per file</option>
                                 </select>
                             </div>
+
+                            <div>
+                                <label class="label" for="repair.stop_schedule">
+                                    <span class="font-medium">Stop schedule <span class="opacity-60 font-normal">(optional)</span></span>
+                                </label>
+                                <input type="text" class="input w-full" name="repair.stop_schedule" id="repair.stop_schedule"
+                                       placeholder="e.g. 06:00, 0 6 * * *, 4h">
+                                <span class="label-text-alt opacity-70">Cron expression, clock time, or interval. If a repair sweep is still running when this fires, it's stopped early. Uses "Auto-repair when broken" below to decide whether to repair whatever was found broken so far.</span>
+                            </div>
                         </div>
 
                         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -1436,6 +1445,7 @@
                         </div>
                     </div>
                 </div>
+
 
             </div>
         </div>


### PR DESCRIPTION
## The problem

On a large library a repair sweep can run for many hours, and there's currently no way to constrain *when* it's allowed to run — only when it starts. If a sweep started overnight is still probing at 9am, it keeps consuming NNTP connections and bandwidth right through peak streaming hours. The only ways out today are letting it run to completion or manually aborting it, and an abort throws the run away as cancelled.

## The feature

This adds an optional `stop_schedule` to the repair config. It accepts the same formats as the existing `schedule` (clock time like `06:00`, standard cron, or an interval like `4h`, via the same `ConvertToJobDef` path). When it fires while a sweep is running, the sweep is stopped early — but treated as a *planned* end of the working window, not an abort:

- **The run is finalized as `completed`, not `cancelled`**, with a note that it was stopped by schedule. A user-initiated stop is unchanged — that path writes its cancelled status before the context is torn down, and finalization preserves it.
- **Whatever the sweep found broken before the stop is handled by the existing `auto_repair` setting**, same as any full sweep: on → repaired via the normal Arr delete + re-search flow; off → recorded as broken and left alone. The final repair pass runs on a fresh context with a 5-minute bound, so the (short, already-known) repair work is allowed to finish even though probing was cut short — and a misbehaving Arr can't hang it.
- **Entries the sweep didn't reach are untouched.** Their health and last-checked timestamps stay as they were, so they're first in line next time.

<img width="1500" height="820" alt="Screenshot 2026-07-18 at 11 12 55" src="https://github.com/user-attachments/assets/3902d203-f7ee-4370-9e41-4fdcdad4380f" />

### Guaranteed forward progress across days

To make a truncated sweep actually useful, candidates are now probed **oldest-checked-first**: never-checked entries first, then least-recently-checked, with name as a deterministic tiebreak. Probing an entry updates its `last_checked_at` immediately, which sends it to the back of the queue for future sweeps.

So a daily sweep with a stop schedule (say `schedule: "0 0 * * *"`, `stop_schedule: "0 9 * * *"`) walks the whole library across successive nights: each night's window picks up exactly where the last one left off, and once a full pass completes the cycle restarts from the oldest. As long as `recheck_interval` is comfortably longer than a full cycle takes, every entry gets probed within its interval. The docs update includes a worked example of this.

## Safety / fallback behaviour

- **Empty `stop_schedule` (the default) changes nothing** — sweeps run to completion exactly as today, and none of the new code is on the path.
- An invalid stop schedule fails at startup with a clear error naming the bad value, rather than silently not stopping.
- The stop job is tagged separately in the scheduler and cleaned up on service stop and reconfigure, so stale stop jobs can't fire against a later run.
- The scheduled stop and a user stop can't get confused: the schedule path signals through a dedicated per-run stop state, and finalization only takes the "completed by schedule" branch when that state was actually set.
- With no sweep in progress, the stop firing is a no-op.

## Testing

`go build ./...` and `go vet ./...` pass clean.

## Why it's worth having

It turns the repair sweep from an all-or-nothing job into something that can be given a nightly working window — a common ask for anyone whose library is too big to probe in one sitting, or who doesn't want probes competing with playback during the day. The window composes with everything that already exists (`auto_repair`, `recheck_interval`, workers, `nntp_connection_percent`) rather than adding a parallel mechanism, and when it's not configured the behaviour is byte-for-byte today's.

## Config / UI / docs

- `stop_schedule` added to `RepairConfig` (documented, included in `IsZero()`)
- Settings page gains an optional "Stop schedule" field with format examples and help text pointing at "Auto-repair when broken" for stop-time behaviour
- `docs/guides/repair.mdx` documents the option, the stop-time semantics, and the multi-day coverage pattern

## Trying it out

A multi-arch Docker test build with this change (alongside my other in-flight fixes) is available at `ghcr.io/themightybattlecat/decypharr:usenet-improvements`, and the merged source is on the `usenet-improvements` branch of my fork. Happy to adjust anything if you'd prefer it shaped differently.