### PR TITLE
feat(repair): validate files with ffprobe during sweeps and optionally reject broken imports

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,13 +222,19 @@ type RepairConfig struct {
 	FFProbeTimeout string `json:"ffprobe_timeout,omitempty"`
 	// FFProbePath overrides the ffprobe binary location. Default: find "ffprobe" on PATH.
 	FFProbePath string `json:"ffprobe_path,omitempty"`
+	// FFProbeOnImport, when true, validates each newly imported download with ffprobe (same checks
+	// as FFProbeCheck, minus the runtime comparison) BEFORE it is reported complete to
+	// Sonarr/Radarr. A file that fails twice is rejected, so the Arr blocklists the release and
+	// grabs another - corrupt downloads never enter the library. Adds seconds and real reads per
+	// import; requires the ffprobe binary and WebDAV. Default off.
+	FFProbeOnImport bool `json:"ffprobe_on_import,omitempty"`
 }
 
 func (r RepairConfig) IsZero() bool {
 	return !r.Enabled && r.Source == "" && r.Schedule == "" && r.Workers == 0 &&
 		r.NNTPConnectionPercent == 0 && r.Strategy == "" && r.RecheckInterval == "" && len(r.Arrs) == 0 &&
 		!r.AutoRepair && !r.SkipNZBRepair && r.StopSchedule == "" &&
-		!r.FFProbeCheck && r.FFProbeTimeout == "" && r.FFProbePath == ""
+		!r.FFProbeCheck && r.FFProbeTimeout == "" && r.FFProbePath == "" && !r.FFProbeOnImport
 }
 
 type Config struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,12 +210,25 @@ type RepairConfig struct {
 	// fires mid-repair-sweep, AutoRepair decides what happens to whatever was
 	// already found broken: repaired if true, left alone if false.
 	StopSchedule string `json:"stop_schedule,omitempty"`
+
+	// FFProbeCheck, when true, additionally validates each file the sweep's STAT probe called
+	// healthy by running ffprobe against the local WebDAV endpoint. Catches files whose article
+	// headers still exist but whose assembled stream is unplayable: purged bodies, mis-assembled
+	// containers with bogus durations, and files with no decodable video/audio streams. Requires
+	// the ffprobe binary on PATH (or FFProbePath) and WebDAV enabled. Default off - it reads real
+	// bytes per file, so sweeps take longer and use provider bandwidth.
+	FFProbeCheck bool `json:"ffprobe_check,omitempty"`
+	// FFProbeTimeout bounds a single ffprobe invocation (e.g. "90s"). Default 90s.
+	FFProbeTimeout string `json:"ffprobe_timeout,omitempty"`
+	// FFProbePath overrides the ffprobe binary location. Default: find "ffprobe" on PATH.
+	FFProbePath string `json:"ffprobe_path,omitempty"`
 }
 
 func (r RepairConfig) IsZero() bool {
 	return !r.Enabled && r.Source == "" && r.Schedule == "" && r.Workers == 0 &&
 		r.NNTPConnectionPercent == 0 && r.Strategy == "" && r.RecheckInterval == "" && len(r.Arrs) == 0 &&
-		!r.AutoRepair && !r.SkipNZBRepair && r.StopSchedule == ""
+		!r.AutoRepair && !r.SkipNZBRepair && r.StopSchedule == "" &&
+		!r.FFProbeCheck && r.FFProbeTimeout == "" && r.FFProbePath == ""
 }
 
 type Config struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,12 +211,12 @@ type RepairConfig struct {
 	// already found broken: repaired if true, left alone if false.
 	StopSchedule string `json:"stop_schedule,omitempty"`
 
-	// FFProbeCheck, when true, additionally validates each file the sweep's STAT probe called
+	// FFProbeCheck, when true, additionally validates each file the repair sweep's STAT probe called
 	// healthy by running ffprobe against the local WebDAV endpoint. Catches files whose article
 	// headers still exist but whose assembled stream is unplayable: purged bodies, mis-assembled
 	// containers with bogus durations, and files with no decodable video/audio streams. Requires
 	// the ffprobe binary on PATH (or FFProbePath) and WebDAV enabled. Default off - it reads real
-	// bytes per file, so sweeps take longer and use provider bandwidth.
+	// bytes per file, so repair sweeps take longer and use provider bandwidth.
 	FFProbeCheck bool `json:"ffprobe_check,omitempty"`
 	// FFProbeTimeout bounds a single ffprobe invocation (e.g. "90s"). Default 90s.
 	FFProbeTimeout string `json:"ffprobe_timeout,omitempty"`

--- a/internal/config/misc.go
+++ b/internal/config/misc.go
@@ -70,12 +70,31 @@ func (c *Config) isNameAllowed(filename string) bool {
 	return slices.Contains(c.AllowedExt, ext)
 }
 
+// videoExtensions lists container/video extensions decypharr treats as
+// playable video (used both to seed the default allowed-extensions list and,
+// via IsVideoFile, to decide which files are worth an ffprobe validation
+// pass). Kept as the single source of truth so the two never drift apart.
+var videoExtensions = strings.Split("webm,m4v,3gp,nsv,ty,strm,rm,rmvb,m3u,ifo,mov,qt,divx,xvid,bivx,nrg,pva,wmv,asf,asx,ogm,ogv,m2v,avi,bin,dat,dvr-ms,mpg,mpeg,mp4,avc,vp3,svq3,nuv,viv,dv,fli,flv,wpl,vob,mkv,mk3d,ts,wtv,m2ts", ",")
+
+// IsVideoFile reports whether filename's extension is a known video/container
+// format. Narrower than IsFileAllowed, which also passes audio formats and
+// respects the user's own allow-list - this is for callers (the ffprobe
+// import gate, the repair sweep) that specifically need "is this worth
+// probing as a video," independent of what the user has configured as
+// downloadable.
+func IsVideoFile(filename string) bool {
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(filename), "."))
+	if ext == "" {
+		return false
+	}
+	return slices.Contains(videoExtensions, ext)
+}
+
 func getDefaultExtensions() []string {
-	videoExts := strings.Split("webm,m4v,3gp,nsv,ty,strm,rm,rmvb,m3u,ifo,mov,qt,divx,xvid,bivx,nrg,pva,wmv,asf,asx,ogm,ogv,m2v,avi,bin,dat,dvr-ms,mpg,mpeg,mp4,avc,vp3,svq3,nuv,viv,dv,fli,flv,wpl,vob,mkv,mk3d,ts,wtv,m2ts", ",")
 	musicExts := strings.Split("MP3,WAV,FLAC,OGG,WMA,AIFF,ALAC,M4A,APE,AC3,DTS,M4P,MID,MIDI,MKA,MP2,MPA,RA,VOC,WV,AMR", ",")
 
 	// Combine both slices
-	allExts := append(videoExts, musicExts...)
+	allExts := append(append([]string{}, videoExtensions...), musicExts...)
 
 	// Convert to lowercase
 	for i, ext := range allExts {

--- a/pkg/arr/content.go
+++ b/pkg/arr/content.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -13,6 +15,7 @@ import (
 type episode struct {
 	Id            int `json:"id"`
 	EpisodeFileID int `json:"episodeFileId"`
+	Runtime       int `json:"runtime"` // minutes; per-episode override of the series runtime
 }
 
 type sonarrSearch struct {
@@ -29,8 +32,9 @@ type radarrSearch struct {
 func (a *Arr) GetMedia(ctx context.Context, mediaId string) ([]Content, error) {
 	// GetReader series
 	type series struct {
-		Title string `json:"title"`
-		Id    int    `json:"id"`
+		Title   string `json:"title"`
+		Id      int    `json:"id"`
+		Runtime int    `json:"runtime"` // minutes; fallback when a specific episode has no runtime
 	}
 	var data []series
 	if a.Type == Radarr {
@@ -63,7 +67,10 @@ func (a *Arr) GetMedia(ctx context.Context, mediaId string) ([]Content, error) {
 		}
 		var ct Content
 
-		episodeFileIDMap := make(map[int]int)
+		// episodesByFile groups every episode Sonarr has mapped to a given
+		// episodeFileId, so a multi-episode file (double episodes, finales)
+		// resolves to all of its episodes rather than just the last one seen.
+		episodesByFile := make(map[int][]episode)
 		ct = Content{
 			Title: d.Title,
 			Id:    d.Id,
@@ -74,25 +81,30 @@ func (a *Arr) GetMedia(ctx context.Context, mediaId string) ([]Content, error) {
 			continue
 		}
 		for _, e := range episodes {
-			episodeFileIDMap[e.EpisodeFileID] = e.Id
+			episodesByFile[e.EpisodeFileID] = append(episodesByFile[e.EpisodeFileID], e)
 		}
 		files := make([]ContentFile, 0)
 		for _, file := range seriesFiles {
-			eId, ok := episodeFileIDMap[file.Id]
-			if !ok {
-				eId = 0
+			matched := episodesByFile[file.Id]
+			eId := 0
+			if len(matched) > 0 {
+				eId = matched[0].Id
 			}
 			if file.Id == 0 || file.Path == "" {
 				// Skip files without path
 				continue
 			}
+			runtimeSec, episodeCount, confirmed := sonarrExpectedRuntime(matched, d.Runtime, file.Path)
 			files = append(files, ContentFile{
-				FileId:       file.Id,
-				Path:         file.Path,
-				Id:           d.Id,
-				EpisodeId:    eId,
-				SeasonNumber: file.SeasonNumber,
-				Size:         file.Size,
+				FileId:                file.Id,
+				Path:                  file.Path,
+				Id:                    d.Id,
+				EpisodeId:             eId,
+				SeasonNumber:          file.SeasonNumber,
+				Size:                  file.Size,
+				RuntimeSec:            runtimeSec,
+				EpisodeCount:          episodeCount,
+				EpisodeCountConfirmed: confirmed,
 			})
 		}
 		if len(files) == 0 {
@@ -103,6 +115,67 @@ func (a *Arr) GetMedia(ctx context.Context, mediaId string) ([]Content, error) {
 		contents = append(contents, ct)
 	}
 	return contents, nil
+}
+
+// multiEpisodeFilenameRe matches an "E01-E02" / "E01E02" / "E01-02" style
+// multi-episode span in a release filename.
+var multiEpisodeFilenameRe = regexp.MustCompile(`(?i)E(\d{1,3})[-. _]?E?(\d{1,3})`)
+
+// sonarrExpectedRuntime derives a file's expected runtime in seconds and its
+// episode count, in preference order:
+//  1. the sum of the per-episode runtimes Sonarr reports for the episodes
+//     actually mapped to this file - exact, and handles variable-length
+//     episodes (finales, anthology shows) correctly.
+//  2. seriesRuntimeMin x episode count, when (1) has no usable per-episode
+//     runtimes but the file is still mapped to a known set of episodes.
+//  3. seriesRuntimeMin x a filename-guessed episode count, when Sonarr has no
+//     episode mapped to this file at all (episodeCountConfirmed=false).
+//
+// Returns runtimeSec=0 when nothing usable is available, signaling "unknown"
+// to the caller (ceiling-only check, no ratio comparison).
+func sonarrExpectedRuntime(matched []episode, seriesRuntimeMin int, path string) (runtimeSec, episodeCount int, confirmed bool) {
+	if len(matched) > 0 {
+		episodeCount = len(matched)
+		confirmed = true
+
+		sum := 0
+		allHaveRuntime := true
+		for _, e := range matched {
+			if e.Runtime <= 0 {
+				allHaveRuntime = false
+				break
+			}
+			sum += e.Runtime * 60
+		}
+		switch {
+		case allHaveRuntime:
+			runtimeSec = sum
+		case seriesRuntimeMin > 0:
+			runtimeSec = seriesRuntimeMin * 60 * episodeCount
+		}
+		return runtimeSec, episodeCount, confirmed
+	}
+
+	episodeCount = multiEpisodeCountFromFilename(filepath.Base(path))
+	if seriesRuntimeMin > 0 {
+		runtimeSec = seriesRuntimeMin * 60 * episodeCount
+	}
+	return runtimeSec, episodeCount, false
+}
+
+// multiEpisodeCountFromFilename returns the number of episodes spanned by a
+// release filename (e.g. "S01E01-E02" -> 2), or 1 when no span is found.
+func multiEpisodeCountFromFilename(name string) int {
+	m := multiEpisodeFilenameRe.FindStringSubmatch(name)
+	if m == nil {
+		return 1
+	}
+	lo, errLo := strconv.Atoi(m[1])
+	hi, errHi := strconv.Atoi(m[2])
+	if errLo != nil || errHi != nil || hi < lo {
+		return 1
+	}
+	return hi - lo + 1
 }
 
 func (a *Arr) GetMovies(ctx context.Context, tvId string) ([]Content, error) {
@@ -129,10 +202,13 @@ func (a *Arr) GetMovies(ctx context.Context, tvId string) ([]Content, error) {
 		files := make([]ContentFile, 0)
 
 		files = append(files, ContentFile{
-			FileId: movie.MovieFile.Id,
-			Id:     movie.Id,
-			Path:   movie.MovieFile.Path,
-			Size:   movie.MovieFile.Size,
+			FileId:                movie.MovieFile.Id,
+			Id:                    movie.Id,
+			Path:                  movie.MovieFile.Path,
+			Size:                  movie.MovieFile.Size,
+			RuntimeSec:            movie.Runtime * 60,
+			EpisodeCount:          1,
+			EpisodeCountConfirmed: true,
 		})
 		ct.Files = files
 		contents = append(contents, ct)

--- a/pkg/arr/types.go
+++ b/pkg/arr/types.go
@@ -6,6 +6,7 @@ type Movie struct {
 	Title         string `json:"title"`
 	OriginalTitle string `json:"originalTitle"`
 	Path          string `json:"path"`
+	Runtime       int    `json:"runtime"` // minutes
 	MovieFile     struct {
 		MovieId      int    `json:"movieId"`
 		RelativePath string `json:"relativePath"`
@@ -29,6 +30,19 @@ type ContentFile struct {
 	SeasonNumber int    `json:"seasonNumber"`
 	Processed    bool   `json:"processed"`
 	Size         int64  `json:"size"`
+
+	// RuntimeSec is this file's expected playback duration in seconds, sourced
+	// from the Arr (movie runtime, or the summed/derived runtime of the
+	// episode(s) the file contains). 0 means unknown - callers should fall
+	// back to a ceiling-only sanity check rather than a ratio comparison.
+	RuntimeSec int `json:"runtimeSec,omitempty"`
+	// EpisodeCount is the number of episodes this file is believed to contain
+	// (1 for movies and single episodes, >1 for multi-episode files).
+	EpisodeCount int `json:"episodeCount,omitempty"`
+	// EpisodeCountConfirmed is true when EpisodeCount came from an actual
+	// Arr episode mapping rather than a filename guess (e.g. an "E01-E02"
+	// span parse). Callers should require a wider safety margin when false.
+	EpisodeCountConfirmed bool `json:"episodeCountConfirmed,omitempty"`
 }
 
 func (file *ContentFile) Delete() {

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -180,13 +180,13 @@ func (d *Downloader) importFFProbeChecker() *ffprobeChecker {
 // ffprobeImportGate validates a newly-completed download with ffprobe before
 // it's reported to the Arr as done. A file confirmed broken (two consecutive
 // ffprobe failures - see ffprobeChecker.checkConfirmed, the same retry-once
-// policy the sweep uses) fails the import instead of completing it, so the
+// policy the repair sweep uses) fails the import instead of completing it, so the
 // existing "download failed" propagation blocklists the release and lets the
 // Arr grab another candidate - the same path today's parse/download failures
 // already take, no new rejection machinery.
 //
 // Deliberately conservative, because wrongly rejecting a good release here is
-// worse than letting a bad file through to the sweep, which will still catch
+// worse than letting a bad file through to the repair sweep, which will still catch
 // it: a timeout or a cancelled context is inconclusive and lets the import
 // proceed, a missing ffprobe binary or disabled WebDAV lets it proceed (after
 // one WARN, see importFFProbeChecker), and any unexpected error from the gate
@@ -196,7 +196,7 @@ func (d *Downloader) importFFProbeChecker() *ffprobeChecker {
 // Only checks structural health - container parses, a video stream exists, a
 // sane duration - plus a category-based ceiling (6h for a Sonarr grab, 12h
 // otherwise), since there's no Arr ContentFile mapping yet to compare a
-// precise expected runtime against. That comparison remains the sweep's job,
+// precise expected runtime against. That comparison remains the repair sweep's job,
 // which runs after the Arr has already imported the file.
 //
 // The whole function is wrapped in a recover(): a panic here must never take

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -27,6 +27,15 @@ type Downloader struct {
 	mountPath string
 	dest      string
 	logger    zerolog.Logger
+
+	// ffprobeImportOnce lazily builds ffprobeImportChecker at most once per
+	// process, the first time an import actually needs it (Repair.FFProbeOnImport
+	// is checked fresh on every call, so flipping the toggle on later still
+	// works) - see importFFProbeChecker. This also means a "checker
+	// unavailable" verdict (missing binary / WebDAV disabled) is remembered
+	// for the rest of the process instead of re-warning on every import.
+	ffprobeImportOnce    sync.Once
+	ffprobeImportChecker *ffprobeChecker
 }
 
 const (
@@ -38,6 +47,11 @@ const (
 	symlinkReadyMaxInterval     = 2 * time.Second
 	symlinkLogEveryAttempts     = 10
 	symlinkLogSampleSize        = 8
+
+	// ffprobeImportMinSize skips ffprobe validation for files smaller than
+	// this at import time, so junk sample clips bundled in an otherwise good
+	// release can't fail the whole grab.
+	ffprobeImportMinSize = 100 * 1024 * 1024 // 100 MiB
 )
 
 type downloadLogMeta struct {
@@ -102,7 +116,11 @@ func (d *Downloader) download(torrent *storage.Entry) error {
 		}
 		// Parent has been fanned out into season entries; mark it complete so
 		// it leaves the downloading queue instead of getting re-processed.
-		d.completeEntry(torrent)
+		// (It has no active files of its own by this point, so the ffprobe
+		// import gate in completeEntry is a no-op here regardless.)
+		if err := d.completeEntry(torrent); err != nil {
+			d.markAsError(torrent, err)
+		}
 		return nil
 	}
 	return d.process(torrent, torrentMountPath)
@@ -117,7 +135,9 @@ func (d *Downloader) process(entry *storage.Entry, mountPath string) error {
 	case config.DownloadActionStrm:
 		return d.processStrm(entry)
 	case config.DownloadActionNone:
-		d.completeEntry(entry)
+		if err := d.completeEntry(entry); err != nil {
+			return err
+		}
 		// Remove entry from queue
 		_ = d.manager.queue.Delete(entry.InfoHash, nil)
 		return nil
@@ -126,10 +146,105 @@ func (d *Downloader) process(entry *storage.Entry, mountPath string) error {
 	}
 }
 
-func (d *Downloader) completeEntry(entry *storage.Entry) {
+// completeEntry is the single choke point every action (symlink, download,
+// strm, none) and both protocols (torrent, NZB) funnel through once their
+// files are in place and servable via WebDAV, right before the entry is
+// reported complete to the Arr. That makes it the natural home for the
+// optional ffprobe import gate: it runs here, before markAsCompleted /
+// notifyCompleted, so a confirmed-broken file never gets reported done.
+func (d *Downloader) completeEntry(entry *storage.Entry) error {
+	if err := d.ffprobeImportGate(entry); err != nil {
+		return err
+	}
 	d.markAsCompleted(entry)
 	d.notifyCompleted(entry)
 	d.triggerArrRefresh(entry)
+	return nil
+}
+
+// importFFProbeChecker returns the shared ffprobe checker for the import
+// gate, building it at most once (see ffprobeImportOnce). Repair.FFProbeOnImport
+// itself is still read fresh on every call so toggling it on later (without a
+// restart) takes effect on the next import.
+func (d *Downloader) importFFProbeChecker() *ffprobeChecker {
+	cfg := config.Get()
+	if !cfg.Repair.FFProbeOnImport {
+		return nil
+	}
+	d.ffprobeImportOnce.Do(func() {
+		d.ffprobeImportChecker = newImportFFProbeChecker(cfg, d.manager, d.logger)
+	})
+	return d.ffprobeImportChecker
+}
+
+// ffprobeImportGate validates a newly-completed download with ffprobe before
+// it's reported to the Arr as done. A file confirmed broken (two consecutive
+// ffprobe failures - see ffprobeChecker.checkConfirmed, the same retry-once
+// policy the sweep uses) fails the import instead of completing it, so the
+// existing "download failed" propagation blocklists the release and lets the
+// Arr grab another candidate - the same path today's parse/download failures
+// already take, no new rejection machinery.
+//
+// Deliberately conservative, because wrongly rejecting a good release here is
+// worse than letting a bad file through to the sweep, which will still catch
+// it: a timeout or a cancelled context is inconclusive and lets the import
+// proceed, a missing ffprobe binary or disabled WebDAV lets it proceed (after
+// one WARN, see importFFProbeChecker), and any unexpected error from the gate
+// itself is swallowed and logged rather than failing the import - this gate
+// must never be the reason a good download breaks.
+//
+// Only checks structural health - container parses, a video stream exists, a
+// sane duration - plus a category-based ceiling (6h for a Sonarr grab, 12h
+// otherwise), since there's no Arr ContentFile mapping yet to compare a
+// precise expected runtime against. That comparison remains the sweep's job,
+// which runs after the Arr has already imported the file.
+//
+// The whole function is wrapped in a recover(): a panic here must never take
+// down the download-completion path every torrent and NZB funnels through,
+// so an unexpected bug in the gate degrades to "proceed without validation"
+// exactly like a missing binary or a timeout would.
+func (d *Downloader) ffprobeImportGate(entry *storage.Entry) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			d.logger.Warn().Interface("panic", r).Str("entry", entry.Name).
+				Msg("Import: ffprobe gate panicked; proceeding without validation")
+			err = nil
+		}
+	}()
+
+	checker := d.importFFProbeChecker()
+	if checker == nil {
+		return nil
+	}
+
+	ctx := d.manager.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	kind := storage.ArrKindOther
+	if a := d.manager.arr.GetOrCreate(entry.Category); a != nil {
+		kind = arrKindFromType(a.Type)
+	}
+	expected := expectedRuntime{ArrKind: kind}
+	entryFolder := entry.GetFolder()
+
+	for _, file := range entry.GetActiveFiles() {
+		if ctx.Err() != nil {
+			// Cancellation (shutdown) is inconclusive, never a rejection.
+			return nil
+		}
+		if file == nil || file.Size < ffprobeImportMinSize || !config.IsVideoFile(file.Name) {
+			continue
+		}
+		ok, reason := checker.checkConfirmed(ctx, entryFolder, file.Name, expected)
+		if !ok {
+			d.logger.Warn().Str("entry", entry.Name).Str("file", file.Name).Str("reason", reason).
+				Msg("Import: ffprobe confirmed broken; rejecting download")
+			return fmt.Errorf("ffprobe import check: %s", reason)
+		}
+	}
+	return nil
 }
 
 func (d *Downloader) markAsCompleted(entry *storage.Entry) {
@@ -222,9 +337,7 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 		}
 	}
 
-	d.completeEntry(entry)
-
-	return nil
+	return d.completeEntry(entry)
 }
 
 func (d *Downloader) createSymlinksWhenMountFilesAppear(entry *storage.Entry, files []*storage.File, mountPath string, symlinkDir string) ([]string, error) {
@@ -542,7 +655,9 @@ func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 	if err := p.Wait(); err != nil {
 		return fmt.Errorf("download failed: %w", err)
 	}
-	d.completeEntry(entry)
+	if err := d.completeEntry(entry); err != nil {
+		return err
+	}
 	d.logger.Info().Msgf("Downloaded all files for %s", entry.Name)
 	return nil
 }
@@ -618,7 +733,9 @@ func (d *Downloader) processUsenetDownload(entry *storage.Entry) error {
 		return fmt.Errorf("NZB download failed: %w", err)
 	}
 
-	d.completeEntry(entry)
+	if err := d.completeEntry(entry); err != nil {
+		return err
+	}
 	d.logger.Info().Msgf("Downloaded all NZB files for %s", entry.Name)
 	return nil
 }
@@ -653,7 +770,9 @@ func (d *Downloader) processStrm(torrent *storage.Entry) error {
 			return fmt.Errorf("failed to create .strm file: %s: %v", strmFilePath, err)
 		}
 	}
-	d.completeEntry(torrent)
+	if err := d.completeEntry(torrent); err != nil {
+		return err
+	}
 	d.logger.Info().Str("destination", torrentSymlinkPath).Msgf("Created .strm files for %s", torrent.Name)
 	return nil
 }

--- a/pkg/manager/ffprobe.go
+++ b/pkg/manager/ffprobe.go
@@ -43,10 +43,24 @@ const (
 	ffprobeTooLongRatioUnconfirmed = 2.5
 	ffprobeTooLongMinOverage       = 60 * time.Minute
 
-	// TOO SHORT: broken when under half the expected runtime and at least 15
-	// minutes short (truncated assembly).
+	// TOO SHORT: candidate for broken when under half the expected runtime and
+	// at least 15 minutes short. On its own this is only metadata-level
+	// evidence: ffprobe reads duration from the container header, which
+	// survives a truncated assembly intact and still reports the encoded
+	// length rather than however much of the stream is actually readable. So
+	// a too-short ratio here is corroborated with a tail read (tailIntact)
+	// before anything is marked broken - it's only trusted as "truncated
+	// assembly" when that tail read also fails; otherwise the file plays to
+	// its own recorded end and the mismatch is Arr metadata being wrong
+	// (as-aired combined runtime, extended-cut listing) rather than the file.
 	ffprobeTooShortRatio    = 0.5
 	ffprobeTooShortMinUnder = 15 * time.Minute
+
+	// ffprobeTailWindow is the span of stream tail demuxed by tailIntact to
+	// corroborate a too-short verdict: packets are read starting this long
+	// before the probed duration, so a real end-of-stream packet lands in the
+	// window rather than being missed by seeking in too late.
+	ffprobeTailWindow = 30 * time.Second
 
 	// Ceiling-only thresholds used when no expected runtime is available.
 	ffprobeCeilingSonarr = 6 * time.Hour
@@ -88,12 +102,18 @@ type ffprobeChecker struct {
 	authToken string
 
 	logger zerolog.Logger
+
+	// tailIntactFn, when set, replaces the tailIntact method. Production
+	// code leaves this nil (check calls f.tailIntact directly); tests set it
+	// to corroborate a too-short verdict without shelling out to a real
+	// ffprobe process.
+	tailIntactFn func(ctx context.Context, entryFolder, fileName string, probed time.Duration) bool
 }
 
-// newFFProbeChecker builds a checker for one sweep run, or returns nil (with
+// newFFProbeChecker builds a checker for one repair sweep run, or returns nil (with
 // exactly one WARN) when ffprobe_check is enabled but can't actually be used:
 // binary missing, or WebDAV disabled. Callers must treat nil as "proceed
-// STAT-only" rather than failing the sweep.
+// STAT-only" rather than failing the repair sweep.
 func newFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffprobeChecker {
 	if !cfg.Repair.FFProbeCheck {
 		return nil
@@ -102,11 +122,11 @@ func newFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffpr
 }
 
 // newImportFFProbeChecker builds a checker for the import-time gate
-// (Repair.FFProbeOnImport), independent of the sweep's own FFProbeCheck
+// (Repair.FFProbeOnImport), independent of the repair sweep's own FFProbeCheck
 // toggle - either can be on without the other. Shares every bit of binary
-// resolution, WebDAV/auth wiring, and timeout parsing with the sweep-side
+// resolution, WebDAV/auth wiring, and timeout parsing with the repair-sweep-side
 // checker via buildFFProbeChecker, and the resulting *ffprobeChecker's
-// check/checkConfirmed methods are exactly the ones the sweep uses - the
+// check/checkConfirmed methods are exactly the ones the repair sweep uses - the
 // import gate is a second caller of the same core, not a parallel
 // implementation.
 func newImportFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffprobeChecker {
@@ -159,6 +179,22 @@ func buildFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ff
 	}
 }
 
+// probeTarget builds the WebDAV URL for entryFolder/fileName that both check
+// and tailIntact probe against.
+func (f *ffprobeChecker) probeTarget(entryFolder, fileName string) string {
+	return f.baseURL + EntryAllFolder + "/" + url.PathEscape(entryFolder) + "/" + url.PathEscape(fileName)
+}
+
+// probeArgs appends the shared -headers auth flag (if any) and the target
+// URL to args, so check and tailIntact only need to supply their own
+// probe-specific flags.
+func (f *ffprobeChecker) probeArgs(entryFolder, fileName string, args []string) []string {
+	if f.authToken != "" {
+		args = append(args, "-headers", "Authorization: Bearer "+f.authToken+"\r\n")
+	}
+	return append(args, f.probeTarget(entryFolder, fileName))
+}
+
 type ffprobeOutput struct {
 	Format struct {
 		Duration string `json:"duration"`
@@ -173,13 +209,7 @@ type ffprobeOutput struct {
 // inconclusive (ok=true) rather than broken - a slow cold read over Usenet
 // must never cause an auto-delete.
 func (f *ffprobeChecker) check(ctx context.Context, entryFolder, fileName string, expected expectedRuntime) (ok bool, reason string) {
-	target := f.baseURL + EntryAllFolder + "/" + url.PathEscape(entryFolder) + "/" + url.PathEscape(fileName)
-
-	args := []string{"-v", "error", "-print_format", "json", "-show_format", "-show_streams"}
-	if f.authToken != "" {
-		args = append(args, "-headers", "Authorization: Bearer "+f.authToken+"\r\n")
-	}
-	args = append(args, target)
+	args := f.probeArgs(entryFolder, fileName, []string{"-v", "error", "-print_format", "json", "-show_format", "-show_streams"})
 
 	cctx, cancel := context.WithTimeout(ctx, f.timeout)
 	defer cancel()
@@ -249,7 +279,20 @@ func (f *ffprobeChecker) check(ctx context.Context, entryFolder, fileName string
 		return false, fmt.Sprintf("%s: probe=%dm expected=%dm (%.1fx)", ffprobeReasonRuntimeMismatch, int(duration.Minutes()), int(expectedDur.Minutes()), ratio)
 	}
 	if ratio <= ffprobeTooShortRatio && expectedDur-duration >= ffprobeTooShortMinUnder {
-		return false, fmt.Sprintf("%s: probe=%dm expected=%dm (%.1fx)", ffprobeReasonRuntimeMismatch, int(duration.Minutes()), int(expectedDur.Minutes()), ratio)
+		tailFn := f.tailIntactFn
+		if tailFn == nil {
+			tailFn = f.tailIntact
+		}
+		if tailFn(ctx, entryFolder, fileName, duration) {
+			f.logger.Info().
+				Str("entry", entryFolder).
+				Str("file", fileName).
+				Int("probe_minutes", int(duration.Minutes())).
+				Int("expected_minutes", int(expectedDur.Minutes())).
+				Msg("Repair: runtime shorter than Arr metadata but stream is complete to its own header duration; treating as metadata mismatch (split release or as-aired special), not marking broken")
+			return true, ""
+		}
+		return false, fmt.Sprintf("%s: probe=%dm expected=%dm (%.1fx); tail_unreadable", ffprobeReasonRuntimeMismatch, int(duration.Minutes()), int(expectedDur.Minutes()), ratio)
 	}
 
 	// Grey zone: meaningfully different from expected but inside the safety
@@ -259,6 +302,82 @@ func (f *ffprobeChecker) check(ctx context.Context, entryFolder, fileName string
 		f.logger.Info().Str("entry", entryFolder).Str("file", fileName).Float64("ratio", ratio).Msg("Repair: ffprobe duration differs from expected but within tolerance; not marking broken")
 	}
 	return true, ""
+}
+
+type ffprobeTailOutput struct {
+	Packets []struct {
+		PtsTime string `json:"pts_time"`
+	} `json:"packets"`
+}
+
+// tailIntact corroborates a too-short verdict by demuxing a window of stream
+// near the probed duration's end and checking that a video packet actually
+// exists there. ffprobe's format duration comes from the container header,
+// which survives a truncated assembly and keeps reporting the encoded
+// length - so a short header duration alone doesn't prove the file is
+// broken. If the stream genuinely reads through to (near) that duration, the
+// short probe is a metadata mismatch (Arr's expected runtime is wrong), not
+// corruption.
+//
+// Like check, a context timeout or cancellation is treated as inconclusive
+// (true) rather than broken - never condemn a file because the corroborating
+// read itself ran out of time.
+func (f *ffprobeChecker) tailIntact(ctx context.Context, entryFolder, fileName string, probed time.Duration) bool {
+	start := probed - ffprobeTailWindow
+	if start < 0 {
+		start = 0
+	}
+	readSpan := ffprobeTailWindow + 15*time.Second
+	interval := fmt.Sprintf("%.0f%%+%.0f", start.Seconds(), readSpan.Seconds())
+
+	args := f.probeArgs(entryFolder, fileName, []string{
+		"-v", "error",
+		"-read_intervals", interval,
+		"-select_streams", "v:0",
+		"-show_entries", "packet=pts_time",
+		"-of", "json",
+	})
+
+	cctx, cancel := context.WithTimeout(ctx, f.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cctx, f.binPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	if cctx.Err() != nil {
+		if errors.Is(cctx.Err(), context.DeadlineExceeded) {
+			f.logger.Debug().Str("entry", entryFolder).Str("file", fileName).Msg("Repair: ffprobe tail check timed out; treating as inconclusive")
+		}
+		return true
+	}
+	if runErr != nil {
+		return false
+	}
+
+	var out ffprobeTailOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		return false
+	}
+
+	const nearEndTolerance = 45 * time.Second
+	for _, p := range out.Packets {
+		sec, err := strconv.ParseFloat(strings.TrimSpace(p.PtsTime), 64)
+		if err != nil {
+			continue
+		}
+		pts := time.Duration(sec * float64(time.Second))
+		diff := probed - pts
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff <= nearEndTolerance {
+			return true
+		}
+	}
+	return false
 }
 
 // checkConfirmed retries once before declaring a file broken: a transient
@@ -296,7 +415,7 @@ func firstLine(s string) string {
 
 // ffprobeCheckerCtxKey carries an optional *ffprobeChecker down through the
 // probe call chain (probeAndHealCandidates -> probeEntry -> probeFiles ->
-// probeFile), which is shared by the timed sweep, the on-demand sweep, and
+// probeFile), which is shared by the timed repair sweep, the on-demand repair sweep, and
 // ad-hoc series/movie rechecks alike - a context value avoids threading a new
 // parameter through every layer for what is, for two of those three
 // call-sites, almost always nil.
@@ -317,7 +436,7 @@ func ffprobeCheckerFromContext(ctx context.Context) *ffprobeChecker {
 // attachFFProbeChecker builds an ffprobe checker for this run when enabled
 // and stores it on ctx for probeFile to pick up. newFFProbeChecker itself
 // logs the one WARN when the flag is on but unusable (missing binary,
-// WebDAV disabled); either way the sweep proceeds STAT-only.
+// WebDAV disabled); either way the repair sweep proceeds STAT-only.
 func (r *Repair) attachFFProbeChecker(ctx context.Context, log zerolog.Logger) context.Context {
 	cfg := config.Get()
 	checker := newFFProbeChecker(cfg, r.manager, log)

--- a/pkg/manager/ffprobe.go
+++ b/pkg/manager/ffprobe.go
@@ -1,0 +1,316 @@
+package manager
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	json "github.com/bytedance/sonic"
+	"github.com/rs/zerolog"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/utils"
+	"github.com/sirrobot01/decypharr/pkg/storage"
+)
+
+// Reasons are prefixed "ffprobe_" so they're greppable in health records
+// alongside the STAT-probe reasons (usenet_segment_missing, etc).
+const (
+	ffprobeReasonUnreadable      = "ffprobe_unreadable"
+	ffprobeReasonNoStreams       = "ffprobe_no_streams"
+	ffprobeReasonNoVideoStream   = "ffprobe_no_video_stream"
+	ffprobeReasonNoDuration      = "ffprobe_no_duration"
+	ffprobeReasonRuntimeMismatch = "ffprobe_runtime_mismatch"
+	ffprobeReasonAbsurdDuration  = "ffprobe_absurd_duration"
+)
+
+const (
+	ffprobeDefaultTimeout = 90 * time.Second
+	ffprobeRetryDelay     = 2 * time.Second
+
+	// TOO LONG: broken when the file runs at least this many times its
+	// expected runtime AND is at least ffprobeTooLongMinOverage over. The
+	// unconfirmed ratio is wider so an unrecognized double-episode file that
+	// happens to land at exactly 2x isn't deleted for being correct; real
+	// extended cuts run ~1.3-1.4x, well under either threshold.
+	ffprobeTooLongRatioConfirmed   = 2.0
+	ffprobeTooLongRatioUnconfirmed = 2.5
+	ffprobeTooLongMinOverage       = 60 * time.Minute
+
+	// TOO SHORT: broken when under half the expected runtime and at least 15
+	// minutes short (truncated assembly).
+	ffprobeTooShortRatio    = 0.5
+	ffprobeTooShortMinUnder = 15 * time.Minute
+
+	// Ceiling-only thresholds used when no expected runtime is available.
+	ffprobeCeilingSonarr = 6 * time.Hour
+	ffprobeCeilingOther  = 12 * time.Hour
+)
+
+// expectedRuntime is what the Arr believes a file's playback duration should
+// be. Seconds == 0 means unknown - the checker falls back to a ceiling-only
+// sanity check rather than a ratio comparison.
+type expectedRuntime struct {
+	Seconds               int
+	EpisodeCountConfirmed bool
+	ArrKind               storage.ArrKind
+}
+
+// ffprobeChecker validates one file's assembled stream by running ffprobe
+// against decypharr's own local WebDAV endpoint. WebDAV supports HTTP Range,
+// giving ffprobe the seekable access it needs (MP4s with a tail moov atom
+// require a seek to EOF; a pipe would false-fail them), and since the read is
+// served in-process it never touches the DFS FUSE downloaders - no risk of
+// tripping the DFS circuit breaker or racing playback-escalation repair.
+type ffprobeChecker struct {
+	binPath string
+	timeout time.Duration
+	baseURL string // e.g. "http://127.0.0.1:8282/webdav/"
+
+	// authToken is the manager's ephemeral, in-memory, per-process bearer
+	// token (see webdav.Handler.isInternalBearer), sent via ffprobe's
+	// -headers flag. It replaces the user's WebDAV password, which is only
+	// ever stored as a bcrypt hash and so cannot be recovered and handed to
+	// an external process. "" when WebDAV auth is off.
+	//
+	// Security note: this token appears in the ffprobe process's argument
+	// list, visible to anything that can read /proc or run `ps` on this
+	// host for the life of that (sub-second to low-second) process. That's
+	// an acceptable trade-off on a typical single-user box, and the
+	// ephemeral, restart-scoped nature of the token bounds the blast radius
+	// of a leak to "until the next restart" rather than forever.
+	authToken string
+
+	logger zerolog.Logger
+}
+
+// newFFProbeChecker builds a checker for one sweep run, or returns nil (with
+// exactly one WARN) when ffprobe_check is enabled but can't actually be used:
+// binary missing, or WebDAV disabled. Callers must treat nil as "proceed
+// STAT-only" rather than failing the sweep.
+func newFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffprobeChecker {
+	if !cfg.Repair.FFProbeCheck {
+		return nil
+	}
+
+	binPath := strings.TrimSpace(cfg.Repair.FFProbePath)
+	if binPath == "" {
+		binPath = "ffprobe"
+	}
+	resolved, err := exec.LookPath(binPath)
+	if err != nil {
+		log.Warn().Err(err).Str("path", binPath).Msg("Repair: ffprobe_check is enabled but the ffprobe binary was not found on PATH; sweep will use STAT-only checks")
+		return nil
+	}
+	if cfg.DisableWebDav {
+		log.Warn().Msg("Repair: ffprobe_check is enabled but WebDAV is disabled (disable_webdav); sweep will use STAT-only checks")
+		return nil
+	}
+
+	timeout := ffprobeDefaultTimeout
+	if raw := strings.TrimSpace(cfg.Repair.FFProbeTimeout); raw != "" {
+		if d, err := utils.ParseDuration(raw); err == nil && d > 0 {
+			timeout = d
+		} else {
+			log.Warn().Str("value", raw).Msg("Repair: invalid repair.ffprobe_timeout; using default of 90s")
+		}
+	}
+
+	var authToken string
+	if cfg.UseAuth && cfg.EnableWebdavAuth {
+		authToken = m.InternalToken()
+	}
+
+	return &ffprobeChecker{
+		binPath:   resolved,
+		timeout:   timeout,
+		baseURL:   fmt.Sprintf("http://127.0.0.1:%s%swebdav/", cfg.Port, cfg.URLBase),
+		authToken: authToken,
+		logger:    log,
+	}
+}
+
+type ffprobeOutput struct {
+	Format struct {
+		Duration string `json:"duration"`
+	} `json:"format"`
+	Streams []struct {
+		CodecType string `json:"codec_type"`
+	} `json:"streams"`
+}
+
+// check runs ffprobe once against entryFolder/fileName and returns whether
+// the file looks healthy. A context timeout or cancellation is treated as
+// inconclusive (ok=true) rather than broken - a slow cold read over Usenet
+// must never cause an auto-delete.
+func (f *ffprobeChecker) check(ctx context.Context, entryFolder, fileName string, expected expectedRuntime) (ok bool, reason string) {
+	target := f.baseURL + EntryAllFolder + "/" + url.PathEscape(entryFolder) + "/" + url.PathEscape(fileName)
+
+	args := []string{"-v", "error", "-print_format", "json", "-show_format", "-show_streams"}
+	if f.authToken != "" {
+		args = append(args, "-headers", "Authorization: Bearer "+f.authToken+"\r\n")
+	}
+	args = append(args, target)
+
+	cctx, cancel := context.WithTimeout(ctx, f.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cctx, f.binPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	if cctx.Err() != nil {
+		if errors.Is(cctx.Err(), context.DeadlineExceeded) {
+			f.logger.Debug().Str("entry", entryFolder).Str("file", fileName).Msg("Repair: ffprobe timed out; treating as inconclusive")
+		}
+		return true, ""
+	}
+	if runErr != nil {
+		return false, ffprobeReasonUnreadable + ": " + firstLine(stderr.String())
+	}
+
+	var probe ffprobeOutput
+	if err := json.Unmarshal(stdout.Bytes(), &probe); err != nil {
+		return false, ffprobeReasonUnreadable + ": " + firstLine(err.Error())
+	}
+
+	hasVideo, hasAudio := false, false
+	for _, s := range probe.Streams {
+		switch s.CodecType {
+		case "video":
+			hasVideo = true
+		case "audio":
+			hasAudio = true
+		}
+	}
+	if !hasVideo && !hasAudio {
+		return false, ffprobeReasonNoStreams
+	}
+	if !hasVideo {
+		return false, ffprobeReasonNoVideoStream
+	}
+
+	durationSec, err := strconv.ParseFloat(strings.TrimSpace(probe.Format.Duration), 64)
+	if err != nil || durationSec <= 0 {
+		return false, ffprobeReasonNoDuration
+	}
+	duration := time.Duration(durationSec * float64(time.Second))
+
+	if expected.Seconds <= 0 {
+		ceiling := ffprobeCeilingOther
+		if expected.ArrKind == storage.ArrKindSonarr {
+			ceiling = ffprobeCeilingSonarr
+		}
+		if duration > ceiling {
+			return false, ffprobeReasonAbsurdDuration
+		}
+		return true, ""
+	}
+
+	expectedDur := time.Duration(expected.Seconds) * time.Second
+	ratio := duration.Seconds() / expectedDur.Seconds()
+
+	tooLongRatio := ffprobeTooLongRatioConfirmed
+	if !expected.EpisodeCountConfirmed {
+		tooLongRatio = ffprobeTooLongRatioUnconfirmed
+	}
+	if ratio >= tooLongRatio && duration-expectedDur >= ffprobeTooLongMinOverage {
+		return false, fmt.Sprintf("%s: probe=%dm expected=%dm (%.1fx)", ffprobeReasonRuntimeMismatch, int(duration.Minutes()), int(expectedDur.Minutes()), ratio)
+	}
+	if ratio <= ffprobeTooShortRatio && expectedDur-duration >= ffprobeTooShortMinUnder {
+		return false, fmt.Sprintf("%s: probe=%dm expected=%dm (%.1fx)", ffprobeReasonRuntimeMismatch, int(duration.Minutes()), int(expectedDur.Minutes()), ratio)
+	}
+
+	// Grey zone: meaningfully different from expected but inside the safety
+	// bands (extended cuts, specials, padded finales). Never auto-delete on
+	// ambiguity - log it and let the file stand.
+	if ratio < 0.9 || ratio > 1.1 {
+		f.logger.Info().Str("entry", entryFolder).Str("file", fileName).Float64("ratio", ratio).Msg("Repair: ffprobe duration differs from expected but within tolerance; not marking broken")
+	}
+	return true, ""
+}
+
+// checkConfirmed retries once before declaring a file broken: a transient
+// cold-seek can fail one read and pass the next, and since a broken verdict
+// can lead to an automatic delete + re-search, a single bad read is never
+// enough. Only a second consecutive broken verdict is returned as broken.
+func (f *ffprobeChecker) checkConfirmed(ctx context.Context, entryFolder, fileName string, expected expectedRuntime) (ok bool, reason string) {
+	ok, reason = f.check(ctx, entryFolder, fileName, expected)
+	if ok {
+		return true, ""
+	}
+	f.logger.Debug().Str("entry", entryFolder).Str("file", fileName).Str("reason", reason).Msg("Repair: ffprobe check failed; retrying once before declaring broken")
+
+	select {
+	case <-ctx.Done():
+		return true, ""
+	case <-time.After(ffprobeRetryDelay):
+	}
+
+	ok, reason = f.check(ctx, entryFolder, fileName, expected)
+	f.logger.Debug().Str("entry", entryFolder).Str("file", fileName).Bool("ok", ok).Str("reason", reason).Msg("Repair: ffprobe retry result")
+	if ok {
+		return true, ""
+	}
+	return false, reason
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// ffprobeCheckerCtxKey carries an optional *ffprobeChecker down through the
+// probe call chain (probeAndHealCandidates -> probeEntry -> probeFiles ->
+// probeFile), which is shared by the timed sweep, the on-demand sweep, and
+// ad-hoc series/movie rechecks alike - a context value avoids threading a new
+// parameter through every layer for what is, for two of those three
+// call-sites, almost always nil.
+type ffprobeCheckerCtxKey struct{}
+
+func contextWithFFProbeChecker(ctx context.Context, checker *ffprobeChecker) context.Context {
+	if checker == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ffprobeCheckerCtxKey{}, checker)
+}
+
+func ffprobeCheckerFromContext(ctx context.Context) *ffprobeChecker {
+	checker, _ := ctx.Value(ffprobeCheckerCtxKey{}).(*ffprobeChecker)
+	return checker
+}
+
+// attachFFProbeChecker builds an ffprobe checker for this run when enabled
+// and stores it on ctx for probeFile to pick up. newFFProbeChecker itself
+// logs the one WARN when the flag is on but unusable (missing binary,
+// WebDAV disabled); either way the sweep proceeds STAT-only.
+func (r *Repair) attachFFProbeChecker(ctx context.Context, log zerolog.Logger) context.Context {
+	cfg := config.Get()
+	checker := newFFProbeChecker(cfg, r.manager, log)
+	return contextWithFFProbeChecker(ctx, checker)
+}
+
+// expectedRuntimeFor resolves the expected playback duration for one file in
+// a candidate entry from its Arr content mapping, when available.
+func expectedRuntimeFor(c *candidate, name string) expectedRuntime {
+	cf, ok := c.contentMap[name]
+	if !ok {
+		return expectedRuntime{ArrKind: c.arrKind}
+	}
+	return expectedRuntime{
+		Seconds:               cf.RuntimeSec,
+		EpisodeCountConfirmed: cf.EpisodeCountConfirmed,
+		ArrKind:               c.arrKind,
+	}
+}

--- a/pkg/manager/ffprobe.go
+++ b/pkg/manager/ffprobe.go
@@ -98,18 +98,41 @@ func newFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffpr
 	if !cfg.Repair.FFProbeCheck {
 		return nil
 	}
+	return buildFFProbeChecker(cfg, m, log)
+}
 
+// newImportFFProbeChecker builds a checker for the import-time gate
+// (Repair.FFProbeOnImport), independent of the sweep's own FFProbeCheck
+// toggle - either can be on without the other. Shares every bit of binary
+// resolution, WebDAV/auth wiring, and timeout parsing with the sweep-side
+// checker via buildFFProbeChecker, and the resulting *ffprobeChecker's
+// check/checkConfirmed methods are exactly the ones the sweep uses - the
+// import gate is a second caller of the same core, not a parallel
+// implementation.
+func newImportFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffprobeChecker {
+	if !cfg.Repair.FFProbeOnImport {
+		return nil
+	}
+	return buildFFProbeChecker(cfg, m, log)
+}
+
+// buildFFProbeChecker does the binary/WebDAV/auth/timeout resolution shared
+// by both newFFProbeChecker and newImportFFProbeChecker. Returns nil (with
+// exactly one WARN) when ffprobe can't actually be used: binary missing, or
+// WebDAV disabled. Callers must treat nil as "proceed without validation"
+// rather than failing whatever they're doing.
+func buildFFProbeChecker(cfg *config.Config, m *Manager, log zerolog.Logger) *ffprobeChecker {
 	binPath := strings.TrimSpace(cfg.Repair.FFProbePath)
 	if binPath == "" {
 		binPath = "ffprobe"
 	}
 	resolved, err := exec.LookPath(binPath)
 	if err != nil {
-		log.Warn().Err(err).Str("path", binPath).Msg("Repair: ffprobe_check is enabled but the ffprobe binary was not found on PATH; sweep will use STAT-only checks")
+		log.Warn().Err(err).Str("path", binPath).Msg("Repair: ffprobe validation is enabled but the ffprobe binary was not found on PATH; proceeding without it")
 		return nil
 	}
 	if cfg.DisableWebDav {
-		log.Warn().Msg("Repair: ffprobe_check is enabled but WebDAV is disabled (disable_webdav); sweep will use STAT-only checks")
+		log.Warn().Msg("Repair: ffprobe validation is enabled but WebDAV is disabled (disable_webdav); proceeding without it")
 		return nil
 	}
 

--- a/pkg/manager/ffprobe_test.go
+++ b/pkg/manager/ffprobe_test.go
@@ -1,0 +1,150 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// newFakeFFProbeBinary writes a stand-in ffprobe executable that ignores its
+// arguments and always prints the given JSON to stdout - enough to drive
+// check()'s first (format+streams) probe without a real ffprobe binary or a
+// real media file. tailIntact's own ffprobe call is covered separately by
+// stubbing tailIntactFn, so the fake binary only ever needs to answer that
+// first call.
+func newFakeFFProbeBinary(t *testing.T, stdoutJSON string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ffprobe")
+	script := "#!/bin/sh\ncat <<'EOF'\n" + stdoutJSON + "\nEOF\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake ffprobe: %v", err)
+	}
+	return path
+}
+
+func newTestFFProbeChecker(t *testing.T, probedSeconds int, tailIntactFn func(ctx context.Context, entryFolder, fileName string, probed time.Duration) bool) *ffprobeChecker {
+	t.Helper()
+	// ffprobe's format.duration is a plain float string of seconds.
+	stdout := fmt.Sprintf(`{"format":{"duration":"%d.000000"},"streams":[{"codec_type":"video"},{"codec_type":"audio"}]}`, probedSeconds)
+	bin := newFakeFFProbeBinary(t, stdout)
+	return &ffprobeChecker{
+		binPath:      bin,
+		timeout:      5 * time.Second,
+		baseURL:      "http://127.0.0.1:1/",
+		logger:       zerolog.Nop(),
+		tailIntactFn: tailIntactFn,
+	}
+}
+
+func TestCheck_TooShort_TailIntact_NotBroken(t *testing.T) {
+	f := newTestFFProbeChecker(t, 900, func(ctx context.Context, entryFolder, fileName string, probed time.Duration) bool {
+		return true
+	})
+
+	ok, reason := f.check(context.Background(), "Some.Show.S01E01", "episode.mkv", expectedRuntime{
+		Seconds:               3600,
+		EpisodeCountConfirmed: true,
+	})
+
+	if !ok {
+		t.Fatalf("expected ok=true (tail intact => metadata mismatch, not broken), got ok=false reason=%q", reason)
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestCheck_TooShort_TailBroken_MarkedBroken(t *testing.T) {
+	f := newTestFFProbeChecker(t, 900, func(ctx context.Context, entryFolder, fileName string, probed time.Duration) bool {
+		return false
+	})
+
+	ok, reason := f.check(context.Background(), "Some.Show.S01E01", "episode.mkv", expectedRuntime{
+		Seconds:               3600,
+		EpisodeCountConfirmed: true,
+	})
+
+	if ok {
+		t.Fatalf("expected ok=false (tail unreadable => broken), got ok=true")
+	}
+	if !strings.Contains(reason, "tail_unreadable") {
+		t.Errorf("reason %q missing tail_unreadable suffix", reason)
+	}
+	if !strings.Contains(reason, ffprobeReasonRuntimeMismatch) {
+		t.Errorf("reason %q missing %s", reason, ffprobeReasonRuntimeMismatch)
+	}
+}
+
+func TestCheck_NormalRuntime_DoesNotCallTailIntact(t *testing.T) {
+	called := false
+	f := newTestFFProbeChecker(t, 3600, func(ctx context.Context, entryFolder, fileName string, probed time.Duration) bool {
+		called = true
+		return true
+	})
+
+	ok, reason := f.check(context.Background(), "Some.Show.S01E01", "episode.mkv", expectedRuntime{
+		Seconds:               3600,
+		EpisodeCountConfirmed: true,
+	})
+
+	if !ok || reason != "" {
+		t.Fatalf("expected ok=true, empty reason for a matching runtime; got ok=%v reason=%q", ok, reason)
+	}
+	if called {
+		t.Error("tailIntactFn should not be called when the ratio isn't too-short")
+	}
+}
+
+func newTailIntactChecker(t *testing.T, script string) *ffprobeChecker {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ffprobe")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake ffprobe: %v", err)
+	}
+	return &ffprobeChecker{
+		binPath: path,
+		timeout: 5 * time.Second,
+		baseURL: "http://127.0.0.1:1/",
+		logger:  zerolog.Nop(),
+	}
+}
+
+func TestTailIntact_PacketNearProbedEnd_ReturnsTrue(t *testing.T) {
+	f := newTailIntactChecker(t, "#!/bin/sh\ncat <<'EOF'\n"+`{"packets":[{"pts_time":"895.500000"}]}`+"\nEOF\n")
+
+	if !f.tailIntact(context.Background(), "entry", "file.mkv", 900*time.Second) {
+		t.Error("expected tailIntact=true for a packet within 45s of the probed duration")
+	}
+}
+
+func TestTailIntact_NoPacketsNearEnd_ReturnsFalse(t *testing.T) {
+	f := newTailIntactChecker(t, "#!/bin/sh\ncat <<'EOF'\n"+`{"packets":[{"pts_time":"10.000000"}]}`+"\nEOF\n")
+
+	if f.tailIntact(context.Background(), "entry", "file.mkv", 900*time.Second) {
+		t.Error("expected tailIntact=false when no packet is within 45s of the probed duration")
+	}
+}
+
+func TestTailIntact_ExecError_ReturnsFalse(t *testing.T) {
+	f := newTailIntactChecker(t, "#!/bin/sh\nexit 1\n")
+
+	if f.tailIntact(context.Background(), "entry", "file.mkv", 900*time.Second) {
+		t.Error("expected tailIntact=false on a non-zero ffprobe exit")
+	}
+}
+
+func TestTailIntact_UnparsableOutput_ReturnsFalse(t *testing.T) {
+	f := newTailIntactChecker(t, "#!/bin/sh\necho 'not json'\n")
+
+	if f.tailIntact(context.Background(), "entry", "file.mkv", 900*time.Second) {
+		t.Error("expected tailIntact=false on unparsable ffprobe output")
+	}
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -2,7 +2,9 @@ package manager
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -69,6 +71,14 @@ type Manager struct {
 	entry      *EntryCache
 	downloader *Downloader
 	usenet     *usenet.Usenet
+
+	// internalToken is a random, in-memory, per-process credential the repair
+	// sweep's ffprobe check presents to the WebDAV auth middleware instead of
+	// the user's WebDAV password: that password is only ever stored as a
+	// bcrypt hash, so there is no plaintext credential available to hand to an
+	// external process. Regenerated (and any prior value invalidated) on
+	// every restart; never persisted.
+	internalToken string
 
 	// Debrid speed test results storage
 	debridSpeedTestResults *xsync.Map[string, debridTypes.SpeedTestResult]
@@ -153,6 +163,7 @@ func New() *Manager {
 		debridSpeedTestResults: xsync.NewMap[string, debridTypes.SpeedTestResult](),
 		activeStreams:          xsync.NewMap[string, *ActiveStream](),
 		processingEntries:      xsync.NewMap[string, struct{}](),
+		internalToken:          generateInternalToken(),
 	}
 
 	instance.init()
@@ -546,6 +557,24 @@ func (m *Manager) Uptime() time.Duration {
 
 func (m *Manager) StartTime() time.Time {
 	return m.startTime
+}
+
+// InternalToken returns the process-lifetime bearer credential the WebDAV
+// auth middleware accepts in place of the (unrecoverable, bcrypt-hashed)
+// WebDAV password. Used by the repair sweep's ffprobe check to authenticate
+// its own reads when WebDAV auth is enabled.
+func (m *Manager) InternalToken() string {
+	return m.internalToken
+}
+
+// generateInternalToken creates a random, per-process token. Never persisted;
+// a fresh value is generated on every restart.
+func generateInternalToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
 }
 
 // CRUD operations

--- a/pkg/manager/repair_sweep.go
+++ b/pkg/manager/repair_sweep.go
@@ -86,6 +86,7 @@ type fileResult struct {
 func (r *Repair) executeSweep(ctx context.Context, run *storage.RepairRun, opts RepairRunOptions, stopState *repairStopState) {
 	cfg := r.cfg()
 	log := r.logger.With().Str("run_id", run.ID).Logger()
+	ctx = r.attachFFProbeChecker(ctx, log)
 
 	// Resolve auto-repair once: when off, the repair sweep is a pure health check —
 	// it probes and records broken state but attempts no debrid re-insert and
@@ -318,7 +319,7 @@ func (r *Repair) probeEntry(ctx context.Context, runID string, c *candidate, hea
 	r.saveHealth(h)
 
 	names := orderedFilenames(c.item)
-	results := r.probeFiles(ctx, c.item, names, opts)
+	results := r.probeFiles(ctx, c, names, opts)
 	if autoRepair {
 		r.autoHealResults(ctx, results, heal)
 	}
@@ -355,7 +356,7 @@ func (r *Repair) probeEntry(ctx context.Context, runID string, c *candidate, hea
 
 // probeFiles fans per-file probes inside a single entry, capped at
 // repairFilesPerEntry concurrent workers.
-func (r *Repair) probeFiles(ctx context.Context, item *storage.EntryItem, names []string, opts RepairRunOptions) []fileResult {
+func (r *Repair) probeFiles(ctx context.Context, c *candidate, names []string, opts RepairRunOptions) []fileResult {
 	results := make([]fileResult, len(names))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(repairFilesPerEntry)
@@ -365,7 +366,7 @@ func (r *Repair) probeFiles(ctx context.Context, item *storage.EntryItem, names 
 				results[i] = fileResult{name: name, reason: "context_cancelled"}
 				return nil
 			}
-			results[i] = r.probeFile(gctx, item, name, opts)
+			results[i] = r.probeFile(gctx, c, name, opts)
 			return nil
 		})
 	}
@@ -375,9 +376,13 @@ func (r *Repair) probeFiles(ctx context.Context, item *storage.EntryItem, names 
 
 // probeFile checks one file. NZB probes use usenet.CheckFile. Torrent probes
 // use the provider CheckFile endpoint unless this run requests unrestrict-link
-// probing.
-func (r *Repair) probeFile(ctx context.Context, item *storage.EntryItem, name string, opts RepairRunOptions) fileResult {
-	file := item.Files[name]
+// probing. When the protocol probe passes and an ffprobe checker is attached
+// to ctx (Repair.FFProbeCheck), the file is additionally validated by reading
+// it back over WebDAV - this is the only check that can catch a STAT-alive,
+// BODY-dead file or a mis-assembled container, since NNTP/provider CheckFile
+// never look past the article/link's existence.
+func (r *Repair) probeFile(ctx context.Context, c *candidate, name string, opts RepairRunOptions) fileResult {
+	file := c.item.Files[name]
 	res := fileResult{name: name}
 
 	if file == nil || file.InfoHash == "" {
@@ -398,9 +403,21 @@ func (r *Repair) probeFile(ctx context.Context, item *storage.EntryItem, name st
 	}
 
 	if entry.IsNZB() {
-		return r.probeNZBFile(ctx, entry, name, res)
+		res = r.probeNZBFile(ctx, entry, name, res)
+	} else {
+		res = r.probeTorrentFile(ctx, entry, file, name, res, opts)
 	}
-	return r.probeTorrentFile(ctx, entry, file, name, res, opts)
+
+	if res.healthy {
+		if checker := ffprobeCheckerFromContext(ctx); checker != nil {
+			if ok, reason := checker.checkConfirmed(ctx, c.name, name, expectedRuntimeFor(c, name)); !ok {
+				res.healthy = false
+				res.broken = true
+				res.reason = reason
+			}
+		}
+	}
+	return res
 }
 
 func (r *Repair) probeNZBFile(ctx context.Context, entry *storage.Entry, name string, res fileResult) fileResult {
@@ -1339,11 +1356,12 @@ func (r *Repair) RecheckEntry(ctx context.Context, entryName string, fix bool) (
 		ctx = r.parentCtx
 	}
 	r.runWG.Go(func() {
+		runCtx := r.attachFFProbeChecker(ctx, r.logger)
 		if fix {
-			r.attachArrContext(ctx, c)
+			r.attachArrContext(runCtx, c)
 		}
 		heal := newHealCache()
-		final := r.probeEntry(ctx, runID, c, heal, RepairRunOptions{}, fix)
+		final := r.probeEntry(runCtx, runID, c, heal, RepairRunOptions{}, fix)
 		if !fix || final.Status != storage.HealthBroken {
 			return
 		}
@@ -1429,6 +1447,7 @@ func (r *Repair) RecheckMedia(ctx context.Context, arrName, mediaID string, fix 
 // executeRecheckMedia is the body of a media recheck. Mirrors executeSweep
 // but scoped to a specific media-id resolved through one or more Arrs.
 func (r *Repair) executeRecheckMedia(ctx context.Context, run *storage.RepairRun, arrs []*arr.Arr, arrName, mediaID string, fix bool) {
+	ctx = r.attachFFProbeChecker(ctx, r.logger)
 	candidates := make(map[string]*candidate)
 	var lastErr error
 	for _, a := range arrs {

--- a/pkg/server/assets/js/config.js
+++ b/pkg/server/assets/js/config.js
@@ -166,6 +166,7 @@ class ConfigManager {
         if ($('repair.stop_schedule')) $('repair.stop_schedule').value = repair.stop_schedule || '';
         if ($('repair.auto_repair')) $('repair.auto_repair').checked = !!repair.auto_repair;
         if ($('repair.skip_nzb_repair')) $('repair.skip_nzb_repair').checked = !!repair.skip_nzb_repair;
+        if ($('repair.ffprobe_check')) $('repair.ffprobe_check').checked = !!repair.ffprobe_check;
     }
 
     collectRepairConfig() {
@@ -185,6 +186,7 @@ class ConfigManager {
             stop_schedule: $('repair.stop_schedule')?.value.trim() || '',
             auto_repair: $('repair.auto_repair')?.checked || false,
             skip_nzb_repair: $('repair.skip_nzb_repair')?.checked || false,
+            ffprobe_check: $('repair.ffprobe_check')?.checked || false,
             arrs,
         };
     }

--- a/pkg/server/assets/js/config.js
+++ b/pkg/server/assets/js/config.js
@@ -167,6 +167,7 @@ class ConfigManager {
         if ($('repair.auto_repair')) $('repair.auto_repair').checked = !!repair.auto_repair;
         if ($('repair.skip_nzb_repair')) $('repair.skip_nzb_repair').checked = !!repair.skip_nzb_repair;
         if ($('repair.ffprobe_check')) $('repair.ffprobe_check').checked = !!repair.ffprobe_check;
+        if ($('repair.ffprobe_on_import')) $('repair.ffprobe_on_import').checked = !!repair.ffprobe_on_import;
     }
 
     collectRepairConfig() {
@@ -187,6 +188,7 @@ class ConfigManager {
             auto_repair: $('repair.auto_repair')?.checked || false,
             skip_nzb_repair: $('repair.skip_nzb_repair')?.checked || false,
             ffprobe_check: $('repair.ffprobe_check')?.checked || false,
+            ffprobe_on_import: $('repair.ffprobe_on_import')?.checked || false,
             arrs,
         };
     }

--- a/pkg/server/templates/config.html
+++ b/pkg/server/templates/config.html
@@ -1447,6 +1447,11 @@
                                        id="repair.ffprobe_check" name="repair.ffprobe_check">
                                 <span class="label-text font-medium">Validate files with ffprobe during sweeps (slower)</span>
                             </label>
+                            <label class="label cursor-pointer justify-start gap-3">
+                                <input type="checkbox" class="checkbox checkbox-primary checkbox-sm"
+                                       id="repair.ffprobe_on_import" name="repair.ffprobe_on_import">
+                                <span class="label-text font-medium">Validate new imports with ffprobe (rejects broken grabs)</span>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/pkg/server/templates/config.html
+++ b/pkg/server/templates/config.html
@@ -1442,6 +1442,11 @@
                                        id="repair.skip_nzb_repair" name="repair.skip_nzb_repair">
                                 <span class="label-text font-medium">Skip NZB repair</span>
                             </label>
+                            <label class="label cursor-pointer justify-start gap-3">
+                                <input type="checkbox" class="checkbox checkbox-primary checkbox-sm"
+                                       id="repair.ffprobe_check" name="repair.ffprobe_check">
+                                <span class="label-text font-medium">Validate files with ffprobe during sweeps (slower)</span>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/pkg/server/templates/config.html
+++ b/pkg/server/templates/config.html
@@ -1445,7 +1445,7 @@
                             <label class="label cursor-pointer justify-start gap-3">
                                 <input type="checkbox" class="checkbox checkbox-primary checkbox-sm"
                                        id="repair.ffprobe_check" name="repair.ffprobe_check">
-                                <span class="label-text font-medium">Validate files with ffprobe during sweeps (slower)</span>
+                                <span class="label-text font-medium">Validate files with ffprobe during repair sweeps (slower)</span>
                             </label>
                             <label class="label cursor-pointer justify-start gap-3">
                                 <input type="checkbox" class="checkbox checkbox-primary checkbox-sm"

--- a/pkg/server/webdav/handler.go
+++ b/pkg/server/webdav/handler.go
@@ -1,7 +1,9 @@
 package webdav
 
 import (
+	"crypto/subtle"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -154,6 +156,11 @@ func (h *Handler) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		if h.isInternalBearer(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		username, password, ok := r.BasicAuth()
 		if !ok || !config.VerifyAuth(username, password) {
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
@@ -162,4 +169,23 @@ func (h *Handler) authMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isInternalBearer accepts the manager's random, in-memory, per-process token
+// as an alternative to the WebDAV username/password. It exists for the repair
+// sweep's ffprobe check: the configured WebDAV password is only ever stored
+// as a bcrypt hash, so there's no plaintext credential available to hand to
+// an external ffprobe process. The token is regenerated on every restart and
+// never persisted, so this bypass has a lifetime and blast radius bounded to
+// the current process.
+func (h *Handler) isInternalBearer(r *http.Request) bool {
+	token := h.manager.InternalToken()
+	if token == "" {
+		return false
+	}
+	after, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(after), []byte(token)) == 1
 }


### PR DESCRIPTION
## The problem

The repair sweep decides a file is healthy by asking the news servers whether its article *headers* still exist (NNTP STAT). That misses a whole class of broken files: providers often keep headers long after the bodies are purged, and STAT says nothing about whether the assembled file is a playable video. So retention-expired releases whose articles now return `430 ARTICLE_NOT_FOUND` on actual reads pass the sweep, as do files with no video/audio streams, nonsense multi-day runtimes, or containers that won't parse. Torrent probes have the same blind spot in milder form — the provider's link check confirms the link exists, not that the file behind it plays. Either way, the user finds out when they press play.

<img width="1172" height="684" alt="ffprobe2" src="https://github.com/user-attachments/assets/ff018bca-fa57-47bc-8775-66f5e6d01e08" />

## What this adds

Two independent, **opt-in** ffprobe checks. Both are protocol-agnostic: the sweep check runs on any file whose protocol probe passed — NZB via the NNTP check, torrents via the provider's link check — and the import gate sits at the single completion choke point both protocols funnel through. The motivation is Usenet, where the header/body divergence lives, but debrid entries get the same protection: a provider link check passing says nothing about whether the served bytes are a playable video either.

### 1. Sweep-side validation (`ffprobe_check`)

After the STAT probe passes, ffprobe reads the assembled file through decypharr's own local WebDAV endpoint and confirms the stream is real: the container parses, a video stream exists, and the duration matches what Sonarr/Radarr expect. Because this reads actual article bodies — not just headers — releases that 430 on read fail here and get repaired, exactly the case STAT waves through. WebDAV provides the HTTP range support ffprobe needs for seeking (MP4 indexes live at the end of the file), works identically for DFS and rclone setups, and keeps the read inside the normal serving path.

The runtime comparison is built to never punish legitimate releases:

- Expected runtime comes from the Arr itself — movie runtime, or the summed per-episode runtimes when Sonarr reports them, else series runtime × episode count. A double-episode finale is compared against 2×, not flagged.
- Tolerance bands are wide: length-broken means at least **double** the expected runtime *and* an hour over, or **under half** *and* 15+ minutes short. Anything in between is logged, never repaired.
- A too-short verdict must also be **corroborated by a tail read**: ffprobe demuxes a window at the end of the stream, and the file is only condemned if it can't read through to its own recorded end. A file complete to its own duration but shorter than the metadata claims is logged as a metadata mismatch and left alone. Without this, an episode listed at its as-aired extended runtime — where every available release is the broadcast cut — gets deleted, re-grabbed, and condemned again the next night, forever.

A file ffprobe confirms broken flows into the exact same repair path as one whose headers are missing.

<img width="1129" height="803" alt="ffrrobe1" src="https://github.com/user-attachments/assets/4d8c5aa1-16e3-4a26-a6f6-f6feb034d25d" />

### 2. Import gate (`ffprobe_on_import`)

The same validation at the door: when a download finishes processing, and *before* the Arr is told it's complete, ffprobe confirms it's a real playable video. Two consecutive failures reject the download, the Arr blocklists the release and grabs another — corrupt files never reach the library. Runtime is only checked against a sanity ceiling here; the precise Arr-runtime comparison stays in the sweep, which runs after the Arr has matched the file.

The toggles are independent — either can be enabled alone.

## Safety / fallback behaviour

Both checks are biased hard toward "when unsure, do nothing", because a wrong broken verdict costs a delete + re-search:

- **Off by default.** ffprobe reads real bytes, so sweeps take longer and use provider bandwidth.
- **Two consecutive failures required** before any file is marked broken or import rejected — a cold first read over Usenet can glitch once and pass on retry.
- **Timeouts and cancellation are always inconclusive**, never broken. At import, inconclusive lets the download through: a bad file that slips the gate is still caught by the sweep, but a wrongly rejected good release is just lost.
- Small files and samples are ignored at the import gate.
- **Missing prerequisites degrade gracefully**: without the ffprobe binary or WebDAV, the sweep logs one warning and falls back to header-only checking; imports proceed as before.
- Auth without weakening anything: the WebDAV password only exists as a bcrypt hash, so there's no plaintext credential to hand to an external process. The manager instead generates a random, in-memory, per-process bearer token at startup — never persisted, invalidated on restart — accepted by the WebDAV middleware only for these internal reads, and passed to ffprobe via `-headers` rather than in the URL.

## Testing

The verdict logic — tolerance bands, tail-read corroboration, inconclusive handling — is unit-tested in `pkg/manager/ffprobe_test.go`. `go build ./...` and `go vet ./...` pass clean.

## Config / UI

- `ffprobe_check`, `ffprobe_on_import`, `ffprobe_timeout` (default 90s), `ffprobe_path` (default: `ffprobe` on PATH) added to the repair config
- Settings page gains toggles for both checks
- Applies to scheduled sweeps, on-demand sweeps, and per-series/movie rechecks alike — they share one probe

<img width="960" height="767" alt="Screenshot 2026-07-18 at 11 24 27" src="https://github.com/user-attachments/assets/26129440-4295-41bf-b474-985e49c4f2e0" />

## Why it's worth having

Header-only checking has a blind spot exactly where it hurts most: the sweep is happy, the file is dead. This closes the gap at both ends — catching broken and retention-expired files already in the library, and stopping corrupt downloads at the door — while staying conservative enough that a healthy library behaves identically with it enabled, just with more certainty.

## Trying it out

A multi-arch Docker test build with this change (alongside my other in-flight fixes) is available at `ghcr.io/themightybattlecat/decypharr:usenet-improvements`, with the merged source on the `usenet-improvements` branch of my fork. Happy to adjust anything if you'd prefer it shaped differently.