### PR TITLE
fix(alldebrid): migrate magnet status to v4.1

### DIFF
--- a/pkg/debrid/providers/alldebrid/alldebrid.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid.go
@@ -26,6 +26,18 @@ import (
 	"go.uber.org/ratelimit"
 )
 
+const (
+	allDebridAPIHost                  = "https://api.alldebrid.com"
+	allDebridMagnetUploadEndpoint     = "/v4/magnet/upload"
+	allDebridMagnetUploadFileEndpoint = "/v4/magnet/upload/file"
+	allDebridMagnetStatusEndpoint     = "/v4.1/magnet/status"
+	allDebridMagnetDeleteEndpoint     = "/v4/magnet/delete"
+	allDebridLinkUnlockEndpoint       = "/v4/link/unlock"
+	allDebridLinkInfosEndpoint        = "/v4/link/infos"
+	allDebridUserEndpoint             = "/v4/user"
+	allDebridUserLinksDeleteEndpoint  = "/v4/user/links/delete"
+)
+
 type AllDebrid struct {
 	Host                  string `json:"host"`
 	APIKey                string
@@ -72,7 +84,7 @@ func New(dc config.Debrid, ratelimits map[string]ratelimit.Limiter) (*AllDebrid,
 		autoExpiresLinksAfter = 48 * time.Hour
 	}
 	ad := &AllDebrid{
-		Host:                  "https://api.alldebrid.com/v4.1",
+		Host:                  allDebridAPIHost,
 		APIKey:                dc.APIKey,
 		accountsManager:       account.NewManager(dc, ratelimits["download"], _log),
 		autoExpiresLinksAfter: autoExpiresLinksAfter,
@@ -90,6 +102,64 @@ func (ad *AllDebrid) Config() config.Debrid {
 
 func (ad *AllDebrid) Logger() zerolog.Logger {
 	return ad.logger
+}
+
+func newAllDebridAPIError(apiErr *errorResponse) error {
+	if apiErr == nil {
+		return fmt.Errorf("alldebrid API error: provider returned an error")
+	}
+
+	switch {
+	case apiErr.Code != "" && apiErr.Message != "":
+		return fmt.Errorf("alldebrid API error: %s: %s", apiErr.Code, apiErr.Message)
+	case apiErr.Code != "":
+		return fmt.Errorf("alldebrid API error: %s", apiErr.Code)
+	case apiErr.Message != "":
+		return fmt.Errorf("alldebrid API error: %s", apiErr.Message)
+	default:
+		return fmt.Errorf("alldebrid API error: provider returned an error")
+	}
+}
+
+func decodeAllDebridResponse(resp *http.Response, result any) error {
+	if resp == nil {
+		return fmt.Errorf("alldebrid API error: empty HTTP response")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("alldebrid API error: reading response: %w", err)
+	}
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		if resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return fmt.Errorf("alldebrid API error: HTTP status %d", resp.StatusCode)
+		}
+		return fmt.Errorf("alldebrid API error: empty response")
+	}
+
+	var envelope apiResponse
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("alldebrid API error: decoding response: %w", err)
+	}
+	if envelope.Status == "error" || envelope.Error != nil {
+		return newAllDebridAPIError(envelope.Error)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("alldebrid API error: HTTP status %d", resp.StatusCode)
+	}
+	if envelope.Status != "success" {
+		return fmt.Errorf("alldebrid API error: unexpected response status %q", envelope.Status)
+	}
+	if result != nil {
+		if err := json.Unmarshal(body, result); err != nil {
+			return fmt.Errorf("alldebrid API error: decoding response data: %w", err)
+		}
+	}
+	return nil
 }
 
 func (ad *AllDebrid) doAccountRequest(account *account.Account, endpoint string, queryParams map[string]string, result any) (*http.Response, error) {
@@ -117,10 +187,8 @@ func (ad *AllDebrid) doAccountRequest(account *account.Account, endpoint string,
 	}
 	defer resp.Body.Close()
 
-	if result != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 && resp.ContentLength != 0 {
-		if err := json.ConfigDefault.NewDecoder(resp.Body).Decode(result); err != nil {
-			return resp, err
-		}
+	if err := decodeAllDebridResponse(resp, result); err != nil {
+		return resp, err
 	}
 
 	return resp, nil
@@ -152,10 +220,8 @@ func (ad *AllDebrid) doRequest(endpoint string, queryParams map[string]string, r
 	}
 	defer resp.Body.Close()
 
-	if result != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 && resp.ContentLength != 0 {
-		if err := json.ConfigDefault.NewDecoder(resp.Body).Decode(result); err != nil {
-			return resp, err
-		}
+	if err := decodeAllDebridResponse(resp, result); err != nil {
+		return resp, err
 	}
 
 	return resp, nil
@@ -182,7 +248,9 @@ func (ad *AllDebrid) doPostFile(endpoint string, fileData []byte, result any) (*
 	if _, err = part.Write(fileData); err != nil {
 		return nil, err
 	}
-	writer.Close()
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), &body)
 	if err != nil {
@@ -196,10 +264,8 @@ func (ad *AllDebrid) doPostFile(endpoint string, fileData []byte, result any) (*
 	}
 	defer resp.Body.Close()
 
-	if result != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		if err := json.ConfigDefault.NewDecoder(resp.Body).Decode(result); err != nil {
-			return resp, err
-		}
+	if err := decodeAllDebridResponse(resp, result); err != nil {
+		return resp, err
 	}
 	return resp, nil
 }
@@ -214,13 +280,9 @@ func (ad *AllDebrid) SubmitMagnet(torrent *types.Torrent) (*types.Torrent, error
 func (ad *AllDebrid) addTorrentFile(torrent *types.Torrent) (*types.Torrent, error) {
 	var data UploadFileResponse
 
-	resp, err := ad.doPostFile("/magnet/upload/file", torrent.Magnet.File, &data)
+	_, err := ad.doPostFile(allDebridMagnetUploadFileEndpoint, torrent.Magnet.File, &data)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
 	}
 
 	files := data.Data.Files
@@ -229,7 +291,7 @@ func (ad *AllDebrid) addTorrentFile(torrent *types.Torrent) (*types.Torrent, err
 	}
 	f := files[0]
 	if f.Error != nil {
-		return nil, fmt.Errorf("alldebrid file upload error: %s", f.Error.Message)
+		return nil, fmt.Errorf("alldebrid file upload: %w", newAllDebridAPIError(f.Error))
 	}
 	torrent.Id = strconv.Itoa(f.ID)
 	torrent.Added = time.Now()
@@ -239,13 +301,9 @@ func (ad *AllDebrid) addTorrentFile(torrent *types.Torrent) (*types.Torrent, err
 func (ad *AllDebrid) addMagnetLink(torrent *types.Torrent) (*types.Torrent, error) {
 	var data UploadMagnetResponse
 
-	resp, err := ad.doRequest("/magnet/upload", map[string]string{"magnets[]": torrent.Magnet.Link}, &data)
+	_, err := ad.doRequest(allDebridMagnetUploadEndpoint, map[string]string{"magnets[]": torrent.Magnet.Link}, &data)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
 	}
 
 	magnets := data.Data.Magnets
@@ -312,63 +370,37 @@ func (ad *AllDebrid) flattenFiles(torrentId string, files []MagnetFile, parentPa
 	return result
 }
 
-func (ad *AllDebrid) GetTorrent(torrentId string) (*types.Torrent, error) {
-	var res TorrentInfoResponse
+func magnetForID(res *MagnetStatusResponse, torrentID string) (magnetInfo, error) {
+	if len(res.Data.Magnets) != 1 {
+		return magnetInfo{}, fmt.Errorf(
+			"alldebrid magnet status for ID %q: expected exactly one magnet, got %d",
+			torrentID,
+			len(res.Data.Magnets),
+		)
+	}
 
-	resp, err := ad.doRequest("/magnet/status", map[string]string{"id": torrentId}, &res)
+	requestedID, err := strconv.Atoi(torrentID)
 	if err != nil {
-		return nil, err
+		return magnetInfo{}, fmt.Errorf("alldebrid magnet status: invalid requested ID %q: %w", torrentID, err)
 	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
+	magnet := res.Data.Magnets[0]
+	if magnet.Id != requestedID {
+		return magnetInfo{}, fmt.Errorf(
+			"alldebrid magnet status for ID %q returned magnet ID %d",
+			torrentID,
+			magnet.Id,
+		)
 	}
-
-	data := res.Data.Magnets
-	status := getAlldebridStatus(data.StatusCode)
-	name := data.Filename
-	t := &types.Torrent{
-		Id:               strconv.Itoa(data.Id),
-		Name:             name,
-		Status:           status,
-		Filename:         name,
-		OriginalFilename: name,
-		Files:            make(map[string]types.File),
-		InfoHash:         data.Hash,
-		Debrid:           ad.config.Name,
-		Added:            time.Unix(data.CompletionDate, 0),
-	}
-	t.Bytes = data.Size
-	t.Seeders = data.Seeders
-	if status == "downloaded" {
-		t.Progress = 100
-		index := -1
-		files := ad.flattenFiles(t.Id, data.Files, "", &index)
-		t.Files = files
-	} else {
-		if data.Size > 0 {
-			t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
-		}
-		t.Speed = data.DownloadSpeed
-	}
-	return t, nil
+	return magnet, nil
 }
 
-func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
-	var res TorrentInfoResponse
-
-	resp, err := ad.doRequest("/magnet/status", map[string]string{"id": t.Id}, &res)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
-	}
-
-	data := res.Data.Magnets
+func (ad *AllDebrid) applyMagnetInfo(t *types.Torrent, data magnetInfo) {
 	status := getAlldebridStatus(data.StatusCode)
 	name := data.Filename
+	if t.Files == nil {
+		t.Files = make(map[string]types.File)
+	}
+	t.Id = strconv.Itoa(data.Id)
 	t.Name = name
 	t.Status = status
 	t.Filename = name
@@ -380,17 +412,51 @@ func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
 		t.InfoHash = data.Hash
 	}
 	t.Added = time.Unix(data.CompletionDate, 0)
-	if status == "downloaded" {
+	if status == types.TorrentStatusDownloaded {
 		t.Progress = 100
 		index := -1
-		files := ad.flattenFiles(t.Id, data.Files, "", &index)
-		t.Files = files
+		t.Files = ad.flattenFiles(t.Id, data.Files, "", &index)
 	} else {
 		if data.Size > 0 {
 			t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
 		}
 		t.Speed = data.DownloadSpeed
 	}
+}
+
+func (ad *AllDebrid) GetTorrent(torrentId string) (*types.Torrent, error) {
+	var res MagnetStatusResponse
+
+	_, err := ad.doRequest(allDebridMagnetStatusEndpoint, map[string]string{"id": torrentId}, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := magnetForID(&res, torrentId)
+	if err != nil {
+		return nil, err
+	}
+	t := &types.Torrent{Files: make(map[string]types.File)}
+	ad.applyMagnetInfo(t, data)
+	return t, nil
+}
+
+func (ad *AllDebrid) UpdateTorrent(t *types.Torrent) error {
+	if t == nil {
+		return fmt.Errorf("alldebrid magnet status: cannot update a nil torrent")
+	}
+	var res MagnetStatusResponse
+
+	_, err := ad.doRequest(allDebridMagnetStatusEndpoint, map[string]string{"id": t.Id}, &res)
+	if err != nil {
+		return err
+	}
+
+	data, err := magnetForID(&res, t.Id)
+	if err != nil {
+		return err
+	}
+	ad.applyMagnetInfo(t, data)
 	return nil
 }
 
@@ -419,13 +485,9 @@ func (ad *AllDebrid) CheckStatus(torrent *types.Torrent) (*types.Torrent, error)
 }
 
 func (ad *AllDebrid) DeleteTorrent(torrentId string) error {
-	resp, err := ad.doRequest("/magnet/delete", map[string]string{"id": torrentId}, nil)
+	_, err := ad.doRequest(allDebridMagnetDeleteEndpoint, map[string]string{"id": torrentId}, nil)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
 	}
 
 	ad.logger.Info().Msgf("Torrent %s deleted from AD", torrentId)
@@ -435,17 +497,9 @@ func (ad *AllDebrid) DeleteTorrent(torrentId string) error {
 func (ad *AllDebrid) fetchDownloadLink(account *account.Account, id string, file *types.File) (types.DownloadLink, error) {
 	var data DownloadLink
 
-	resp, err := ad.doAccountRequest(account, "/link/unlock", map[string]string{"link": file.Link}, &data)
+	_, err := ad.doAccountRequest(account, allDebridLinkUnlockEndpoint, map[string]string{"link": file.Link}, &data)
 	if err != nil {
 		return types.DownloadLink{}, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return types.DownloadLink{}, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
-	}
-
-	if data.Error != nil {
-		return types.DownloadLink{}, fmt.Errorf("error getting download link: %s", data.Error.Message)
 	}
 	link := data.Data.Link
 	if link == "" {
@@ -472,15 +526,11 @@ func (ad *AllDebrid) GetDownloadLink(id string, file *types.File) (types.Downloa
 
 func (ad *AllDebrid) GetTorrents() ([]*types.Torrent, error) {
 	torrents := make([]*types.Torrent, 0)
-	var res TorrentsListResponse
+	var res MagnetStatusResponse
 
-	resp, err := ad.doRequest("/magnet/status", map[string]string{"status": "ready"}, &res)
+	_, err := ad.doRequest(allDebridMagnetStatusEndpoint, map[string]string{"status": "ready"}, &res)
 	if err != nil {
 		return torrents, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return torrents, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
 	}
 
 	cfg := config.Get()
@@ -530,7 +580,7 @@ func (ad *AllDebrid) CheckFile(ctx context.Context, _, link string) error {
 	form := url.Values{}
 	form.Add("link[]", link)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ad.Host+"/link/infos", strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ad.Host+allDebridLinkInfosEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err
 	}
@@ -542,20 +592,9 @@ func (ad *AllDebrid) CheckFile(ctx context.Context, _, link string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
-	}
-
 	var data LinkInfosResponse
-	if err := json.ConfigDefault.NewDecoder(resp.Body).Decode(&data); err != nil {
+	if err := decodeAllDebridResponse(resp, &data); err != nil {
 		return err
-	}
-	if data.Status != "success" {
-		message := "unknown error"
-		if data.Error != nil {
-			message = data.Error.Message
-		}
-		return fmt.Errorf("alldebrid API error: %s", message)
 	}
 	if len(data.Data.Infos) != 1 {
 		return fmt.Errorf("alldebrid API error: expected one link info, got %d", len(data.Data.Infos))
@@ -577,21 +616,9 @@ func (ad *AllDebrid) GetProfile() (*types.Profile, error) {
 	}
 	var res UserProfileResponse
 
-	resp, err := ad.doRequest("/user", nil, &res)
+	_, err := ad.doRequest(allDebridUserEndpoint, nil, &res)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
-	}
-
-	if res.Status != "success" {
-		message := "unknown error"
-		if res.Error != nil {
-			message = res.Error.Message
-		}
-		return nil, fmt.Errorf("error getting user profile: %s", message)
 	}
 	userData := res.Data.User
 	expiration := time.Unix(userData.PremiumUntil, 0)
@@ -628,13 +655,9 @@ func (ad *AllDebrid) SyncAccounts() {
 }
 
 func (ad *AllDebrid) deleteLink(account *account.Account, downloadLink types.DownloadLink) error {
-	resp, err := ad.doAccountRequest(account, "/user/links/delete", map[string]string{"links": downloadLink.Link}, nil)
+	_, err := ad.doAccountRequest(account, allDebridUserLinksDeleteEndpoint, map[string]string{"links": downloadLink.Link}, nil)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("alldebrid API error: Status: %d", resp.StatusCode)
 	}
 	return nil
 }
@@ -651,7 +674,7 @@ func (ad *AllDebrid) SpeedTest(ctx context.Context) types.SpeedTestResult {
 	}
 
 	start := time.Now()
-	resp, err := ad.doRequest("/user", nil, nil)
+	_, err := ad.doRequest(allDebridUserEndpoint, nil, nil)
 	latency := time.Since(start)
 
 	if err != nil {
@@ -659,10 +682,6 @@ func (ad *AllDebrid) SpeedTest(ctx context.Context) types.SpeedTestResult {
 		return result
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		result.Error = fmt.Sprintf("latency test unexpected status: %d", resp.StatusCode)
-		return result
-	}
 	result.LatencyMs = latency.Milliseconds()
 
 	// Try to measure download speed using a cached link

--- a/pkg/debrid/providers/alldebrid/alldebrid_test.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid_test.go
@@ -1,0 +1,507 @@
+package alldebrid
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/request"
+	"github.com/sirrobot01/decypharr/internal/utils"
+	"github.com/sirrobot01/decypharr/pkg/debrid/account"
+	"github.com/sirrobot01/decypharr/pkg/debrid/types"
+)
+
+func TestMain(m *testing.M) {
+	configDir, err := os.MkdirTemp("", "decypharr-alldebrid-test-")
+	if err != nil {
+		panic(err)
+	}
+	config.SetConfigPath(configDir)
+
+	code := m.Run()
+	_ = os.RemoveAll(configDir)
+	os.Exit(code)
+}
+
+func newTestAllDebrid(t *testing.T, handler http.HandlerFunc) *AllDebrid {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	debridConfig := config.Debrid{
+		Name:            "test-alldebrid",
+		APIKey:          "main-token",
+		DownloadAPIKeys: []string{"download-token"},
+	}
+	testLogger := zerolog.Nop()
+	clientOptions := []request.ClientOption{
+		request.WithMaxRetries(0),
+		request.WithTimeout(2 * time.Second),
+	}
+
+	return &AllDebrid{
+		Host:                  server.URL,
+		APIKey:                debridConfig.APIKey,
+		accountsManager:       account.NewManager(debridConfig, nil, testLogger),
+		autoExpiresLinksAfter: time.Hour,
+		client:                request.New(clientOptions...),
+		repairClient:          request.New(clientOptions...),
+		logger:                testLogger,
+		config:                debridConfig,
+	}
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := io.WriteString(w, body); err != nil {
+		t.Errorf("write response: %v", err)
+	}
+}
+
+func TestAllDebridEndpointVersions(t *testing.T) {
+	if allDebridAPIHost != "https://api.alldebrid.com" {
+		t.Fatalf("API host = %q, want unversioned HTTPS host", allDebridAPIHost)
+	}
+
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{name: "magnet upload", endpoint: allDebridMagnetUploadEndpoint, want: "/v4/magnet/upload"},
+		{name: "torrent upload", endpoint: allDebridMagnetUploadFileEndpoint, want: "/v4/magnet/upload/file"},
+		{name: "magnet status", endpoint: allDebridMagnetStatusEndpoint, want: "/v4.1/magnet/status"},
+		{name: "magnet delete", endpoint: allDebridMagnetDeleteEndpoint, want: "/v4/magnet/delete"},
+		{name: "link unlock", endpoint: allDebridLinkUnlockEndpoint, want: "/v4/link/unlock"},
+		{name: "link infos", endpoint: allDebridLinkInfosEndpoint, want: "/v4/link/infos"},
+		{name: "user", endpoint: allDebridUserEndpoint, want: "/v4/user"},
+		{name: "user link delete", endpoint: allDebridUserLinksDeleteEndpoint, want: "/v4/user/links/delete"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.endpoint != test.want {
+				t.Fatalf("endpoint = %q, want %q", test.endpoint, test.want)
+			}
+		})
+	}
+}
+
+func TestGetTorrentsUsesV41StatusAndDecodesArray(t *testing.T) {
+	ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != allDebridMagnetStatusEndpoint {
+			t.Errorf("path = %q, want %q", r.URL.Path, allDebridMagnetStatusEndpoint)
+		}
+		if got := r.URL.Query().Get("status"); got != "ready" {
+			t.Errorf("status query = %q, want ready", got)
+		}
+		writeTestJSON(t, w, `{
+			"status": "success",
+			"data": {
+				"magnets": [
+					{
+						"id": 41,
+						"filename": "ready.mkv",
+						"hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						"size": 1000,
+						"status": "Ready",
+						"statusCode": 4,
+						"completionDate": 1700000000
+					},
+					{
+						"id": 42,
+						"filename": "active.mkv",
+						"hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						"size": 2000,
+						"status": "Downloading",
+						"statusCode": 1,
+						"downloaded": 500,
+						"downloadSpeed": 123
+					}
+				]
+			}
+		}`)
+	})
+
+	torrents, err := ad.GetTorrents()
+	if err != nil {
+		t.Fatalf("GetTorrents() error = %v", err)
+	}
+	if len(torrents) != 2 {
+		t.Fatalf("len(torrents) = %d, want 2", len(torrents))
+	}
+	if torrents[0].Id != "41" || torrents[0].Status != types.TorrentStatusDownloaded {
+		t.Errorf("first torrent = %#v, want ID 41 downloaded", torrents[0])
+	}
+	if torrents[1].Id != "42" || torrents[1].Status != types.TorrentStatusDownloading {
+		t.Errorf("second torrent = %#v, want ID 42 downloading", torrents[1])
+	}
+}
+
+func TestGetTorrentUsesV41ArrayAndFlattensFiles(t *testing.T) {
+	ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != allDebridMagnetStatusEndpoint {
+			t.Errorf("path = %q, want %q", r.URL.Path, allDebridMagnetStatusEndpoint)
+		}
+		if got := r.URL.Query().Get("id"); got != "123456" {
+			t.Errorf("id query = %q, want 123456", got)
+		}
+		writeTestJSON(t, w, `{
+			"status": "success",
+			"data": {
+				"magnets": [
+					{
+						"id": 123456,
+						"filename": "example-release",
+						"hash": "1234567890abcdef1234567890abcdef12345678",
+						"size": 1000,
+						"status": "Ready",
+						"statusCode": 4,
+						"seeders": 9,
+						"completionDate": 1700000000,
+						"files": [
+							{
+								"n": "movie.mkv",
+								"s": 900,
+								"l": "https://alldebrid.com/f/movie"
+							},
+							{
+								"n": "extras",
+								"e": [
+									{
+										"n": "feature.mp4",
+										"s": 100,
+										"l": "https://alldebrid.com/f/feature"
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		}`)
+	})
+
+	torrent, err := ad.GetTorrent("123456")
+	if err != nil {
+		t.Fatalf("GetTorrent() error = %v", err)
+	}
+	if torrent.Id != "123456" {
+		t.Errorf("ID = %q, want 123456", torrent.Id)
+	}
+	if torrent.Status != types.TorrentStatusDownloaded || torrent.Progress != 100 {
+		t.Errorf("status/progress = %q/%v, want downloaded/100", torrent.Status, torrent.Progress)
+	}
+	if torrent.InfoHash != "1234567890abcdef1234567890abcdef12345678" {
+		t.Errorf("hash = %q", torrent.InfoHash)
+	}
+	if len(torrent.Files) != 2 {
+		t.Fatalf("len(files) = %d, want 2", len(torrent.Files))
+	}
+	nested, ok := torrent.Files["feature.mp4"]
+	if !ok {
+		t.Fatalf("nested file feature.mp4 missing: %#v", torrent.Files)
+	}
+	if nested.Path != filepath.Join("extras", "feature.mp4") {
+		t.Errorf("nested path = %q, want %q", nested.Path, filepath.Join("extras", "feature.mp4"))
+	}
+	if nested.Link != "https://alldebrid.com/f/feature" {
+		t.Errorf("nested link = %q", nested.Link)
+	}
+}
+
+func TestUpdateTorrentUsesV41Array(t *testing.T) {
+	ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != allDebridMagnetStatusEndpoint {
+			t.Errorf("path = %q, want %q", r.URL.Path, allDebridMagnetStatusEndpoint)
+		}
+		if got := r.URL.Query().Get("id"); got != "77" {
+			t.Errorf("id query = %q, want 77", got)
+		}
+		writeTestJSON(t, w, `{
+			"status": "success",
+			"data": {
+				"magnets": [
+					{
+						"id": 77,
+						"filename": "active-release",
+						"hash": "7777777777777777777777777777777777777777",
+						"size": 1000,
+						"status": "Downloading",
+						"statusCode": 1,
+						"downloaded": 250,
+						"downloadSpeed": 12345,
+						"seeders": 7
+					}
+				]
+			}
+		}`)
+	})
+
+	torrent := &types.Torrent{Id: "77"}
+	if err := ad.UpdateTorrent(torrent); err != nil {
+		t.Fatalf("UpdateTorrent() error = %v", err)
+	}
+	if torrent.Status != types.TorrentStatusDownloading {
+		t.Errorf("status = %q, want downloading", torrent.Status)
+	}
+	if torrent.Progress != 25 {
+		t.Errorf("progress = %v, want 25", torrent.Progress)
+	}
+	if torrent.Speed != 12345 || torrent.Seeders != 7 {
+		t.Errorf("speed/seeders = %d/%d, want 12345/7", torrent.Speed, torrent.Seeders)
+	}
+}
+
+func TestGetTorrentValidatesExactlyOneMatchingID(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   string
+		wantErrSub string
+	}{
+		{
+			name:       "empty",
+			response:   `{"status":"success","data":{"magnets":[]}}`,
+			wantErrSub: "expected exactly one magnet, got 0",
+		},
+		{
+			name:       "multiple",
+			response:   `{"status":"success","data":{"magnets":[{"id":42},{"id":43}]}}`,
+			wantErrSub: "expected exactly one magnet, got 2",
+		},
+		{
+			name:       "mismatched ID",
+			response:   `{"status":"success","data":{"magnets":[{"id":43}]}}`,
+			wantErrSub: "returned magnet ID 43",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+				writeTestJSON(t, w, test.response)
+			})
+
+			_, err := ad.GetTorrent("42")
+			if err == nil {
+				t.Fatal("GetTorrent() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), test.wantErrSub) {
+				t.Fatalf("error = %q, want substring %q", err, test.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestHTTP200TopLevelAPIErrors(t *testing.T) {
+	t.Run("status discontinued", func(t *testing.T) {
+		ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+			writeTestJSON(t, w, `{
+				"status": "error",
+				"error": {
+					"code": "DISCONTINUED",
+					"message": "This API endpoint has been discontinued"
+				}
+			}`)
+		})
+
+		_, err := ad.GetTorrents()
+		if err == nil {
+			t.Fatal("GetTorrents() error = nil")
+		}
+		if !strings.Contains(err.Error(), "DISCONTINUED") ||
+			!strings.Contains(err.Error(), "This API endpoint has been discontinued") {
+			t.Fatalf("error = %q, want provider code and message", err)
+		}
+	})
+
+	t.Run("upload rejection", func(t *testing.T) {
+		ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != allDebridMagnetUploadEndpoint {
+				t.Errorf("path = %q, want %q", r.URL.Path, allDebridMagnetUploadEndpoint)
+			}
+			writeTestJSON(t, w, `{
+				"status": "error",
+				"error": {
+					"code": "MAGNET_TOO_MANY_ACTIVE",
+					"message": "Already have maximum allowed active magnets"
+				}
+			}`)
+		})
+
+		torrent := &types.Torrent{
+			Magnet: &utils.Magnet{Link: "magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		}
+		_, err := ad.SubmitMagnet(torrent)
+		if err == nil {
+			t.Fatal("SubmitMagnet() error = nil")
+		}
+		if !strings.Contains(err.Error(), "MAGNET_TOO_MANY_ACTIVE") ||
+			!strings.Contains(err.Error(), "Already have maximum allowed active magnets") {
+			t.Fatalf("error = %q, want provider code and message", err)
+		}
+	})
+}
+
+func TestNonStatusOperationsUseV4Routes(t *testing.T) {
+	var mu sync.Mutex
+	seen := make(map[string]int)
+
+	ad := newTestAllDebrid(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen[r.URL.Path]++
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case allDebridMagnetUploadEndpoint:
+			if r.Method != http.MethodGet {
+				t.Errorf("magnet upload method = %s, want GET", r.Method)
+			}
+			if got := r.URL.Query().Get("magnets[]"); got == "" {
+				t.Error("magnet upload query is empty")
+			}
+			writeTestJSON(t, w, `{"status":"success","data":{"magnets":[{"id":41}]}}`)
+		case allDebridMagnetUploadFileEndpoint:
+			if r.Method != http.MethodPost {
+				t.Errorf("torrent upload method = %s, want POST", r.Method)
+			}
+			if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data;") {
+				t.Errorf("torrent upload content type = %q", r.Header.Get("Content-Type"))
+			}
+			writeTestJSON(t, w, `{"status":"success","data":{"files":[{"id":42}]}}`)
+		case allDebridMagnetDeleteEndpoint:
+			if got := r.URL.Query().Get("id"); got != "41" {
+				t.Errorf("delete id = %q, want 41", got)
+			}
+			writeTestJSON(t, w, `{"status":"success","data":{"message":"deleted"}}`)
+		case allDebridUserEndpoint:
+			writeTestJSON(t, w, `{
+				"status":"success",
+				"data":{"user":{"username":"demo","email":"demo@example.com","isPremium":true,"premiumUntil":2000000000}}
+			}`)
+		case allDebridLinkInfosEndpoint:
+			if r.Method != http.MethodPost {
+				t.Errorf("link infos method = %s, want POST", r.Method)
+			}
+			writeTestJSON(t, w, `{"status":"success","data":{"infos":[{}]}}`)
+		case allDebridLinkUnlockEndpoint:
+			if got := r.URL.Query().Get("link"); got == "" {
+				t.Error("link unlock query is empty")
+			}
+			writeTestJSON(t, w, `{
+				"status":"success",
+				"data":{"link":"https://download.example/movie.mkv","id":"download-id"}
+			}`)
+		case allDebridUserLinksDeleteEndpoint:
+			if got := r.URL.Query().Get("links"); got == "" {
+				t.Error("user link delete query is empty")
+			}
+			writeTestJSON(t, w, `{"status":"success","data":{"message":"deleted"}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	})
+
+	magnetTorrent := &types.Torrent{
+		Magnet: &utils.Magnet{Link: "magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+	}
+	if _, err := ad.SubmitMagnet(magnetTorrent); err != nil {
+		t.Fatalf("SubmitMagnet(link) error = %v", err)
+	}
+	fileTorrent := &types.Torrent{Magnet: &utils.Magnet{File: []byte("torrent-data")}}
+	if _, err := ad.SubmitMagnet(fileTorrent); err != nil {
+		t.Fatalf("SubmitMagnet(file) error = %v", err)
+	}
+	if err := ad.DeleteTorrent("41"); err != nil {
+		t.Fatalf("DeleteTorrent() error = %v", err)
+	}
+	if _, err := ad.GetProfile(); err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if err := ad.CheckFile(context.Background(), "", "https://alldebrid.com/f/movie"); err != nil {
+		t.Fatalf("CheckFile() error = %v", err)
+	}
+
+	currentAccount := ad.accountsManager.Current()
+	if currentAccount == nil {
+		t.Fatal("test download account is nil")
+	}
+	file := &types.File{
+		Name: "movie.mkv",
+		Size: 100,
+		Link: "https://alldebrid.com/f/movie",
+	}
+	if _, err := ad.fetchDownloadLink(currentAccount, "", file); err != nil {
+		t.Fatalf("fetchDownloadLink() error = %v", err)
+	}
+	if err := ad.deleteLink(currentAccount, types.DownloadLink{Link: file.Link}); err != nil {
+		t.Fatalf("deleteLink() error = %v", err)
+	}
+
+	expected := []string{
+		allDebridMagnetUploadEndpoint,
+		allDebridMagnetUploadFileEndpoint,
+		allDebridMagnetDeleteEndpoint,
+		allDebridUserEndpoint,
+		allDebridLinkInfosEndpoint,
+		allDebridLinkUnlockEndpoint,
+		allDebridUserLinksDeleteEndpoint,
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, endpoint := range expected {
+		if seen[endpoint] != 1 {
+			t.Errorf("requests to %s = %d, want 1", endpoint, seen[endpoint])
+		}
+		if strings.HasPrefix(endpoint, "/v4.1/") {
+			t.Errorf("non-status endpoint unexpectedly uses v4.1: %s", endpoint)
+		}
+	}
+}
+
+func TestGetAlldebridStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want types.TorrentStatus
+	}{
+		{code: -1, want: types.TorrentStatusError},
+		{code: 0, want: types.TorrentStatusDownloading},
+		{code: 1, want: types.TorrentStatusDownloading},
+		{code: 2, want: types.TorrentStatusDownloading},
+		{code: 3, want: types.TorrentStatusDownloading},
+		{code: 4, want: types.TorrentStatusDownloaded},
+		{code: 5, want: types.TorrentStatusError},
+		{code: 6, want: types.TorrentStatusError},
+		{code: 7, want: types.TorrentStatusError},
+		{code: 8, want: types.TorrentStatusError},
+		{code: 9, want: types.TorrentStatusError},
+		{code: 10, want: types.TorrentStatusError},
+		{code: 11, want: types.TorrentStatusError},
+		{code: 12, want: types.TorrentStatusError},
+		{code: 13, want: types.TorrentStatusError},
+		{code: 14, want: types.TorrentStatusError},
+		{code: 15, want: types.TorrentStatusError},
+		{code: 16, want: types.TorrentStatusError},
+	}
+
+	for _, test := range tests {
+		if got := getAlldebridStatus(test.code); got != test.want {
+			t.Errorf("getAlldebridStatus(%d) = %q, want %q", test.code, got, test.want)
+		}
+	}
+}

--- a/pkg/debrid/providers/alldebrid/types.go
+++ b/pkg/debrid/providers/alldebrid/types.go
@@ -1,14 +1,13 @@
 package alldebrid
 
-import (
-	"fmt"
-
-	json "github.com/bytedance/sonic"
-)
-
 type errorResponse struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+type apiResponse struct {
+	Status string         `json:"status"`
+	Error  *errorResponse `json:"error"`
 }
 
 type MagnetFile struct {
@@ -38,20 +37,10 @@ type magnetInfo struct {
 	Files          []MagnetFile `json:"files"`
 }
 
-type Magnets []magnetInfo
-
-type TorrentInfoResponse struct {
+type MagnetStatusResponse struct {
 	Status string `json:"status"`
 	Data   struct {
-		Magnets magnetInfo `json:"magnets"`
-	} `json:"data"`
-	Error *errorResponse `json:"error"`
-}
-
-type TorrentsListResponse struct {
-	Status string `json:"status"`
-	Data   struct {
-		Magnets Magnets `json:"magnets"`
+		Magnets []magnetInfo `json:"magnets"`
 	} `json:"data"`
 	Error *errorResponse `json:"error"`
 }
@@ -114,30 +103,6 @@ type LinkInfosResponse struct {
 		} `json:"infos"`
 	} `json:"data"`
 	Error *errorResponse `json:"error"`
-}
-
-// UnmarshalJSON implements custom unmarshaling for Magnets type
-// It can handle both an array of magnetInfo objects or a map with string keys.
-// If the input is an array, it will be unmarshaled directly into the Magnets slice.
-// If the input is a map, it will extract the values and append them to the Magnets slice.
-// If the input is neither, it will return an error.
-func (m *Magnets) UnmarshalJSON(data []byte) error {
-	// Try to unmarshal as array
-	var arr []magnetInfo
-	if err := json.Unmarshal(data, &arr); err == nil {
-		*m = arr
-		return nil
-	}
-
-	// Try to unmarshal as map
-	var obj map[string]magnetInfo
-	if err := json.Unmarshal(data, &obj); err == nil {
-		for _, v := range obj {
-			*m = append(*m, v)
-		}
-		return nil
-	}
-	return fmt.Errorf("magnets: unsupported JSON format")
 }
 
 type UserProfileResponse struct {


### PR DESCRIPTION
## Summary

- route only AllDebrid magnet-status requests through `/v4.1/magnet/status`
- keep upload, delete, user, and link operations on their supported `/v4` endpoints
- parse the v4.1 `data.magnets` array for both list and per-ID requests and verify that a per-ID response matches the requested magnet
- surface AllDebrid JSON-envelope errors even when the HTTP response itself is 2xx
- add regression coverage for endpoint routing, response shapes, state updates, error envelopes, and unchanged status-code mapping

## Why

AllDebrid discontinued `/v4/magnet/status`. Decypharr currently treats its HTTP-200 `DISCONTINUED` response as an empty result, leaving AllDebrid downloads stale and making add/status polling fail or time out.

The current AllDebrid documentation lists magnet status at `/v4.1/magnet/status`, while upload/delete/user/link endpoints remain under `/v4`.

## Validation

- `go test ./...`
- `go vet ./...`
- focused AllDebrid tests cover bulk status, per-ID status, endpoint versions, API errors, malformed/empty responses, and state transitions

A combined multi-architecture image containing this and the related reliability fixes is also being exercised from the fork before the remaining patches are proposed separately.