### PR TITLE
fix(manager): refuse RemoveAll at or above the category directory

### DIFF
--- a/internal/utils/regex.go
+++ b/internal/utils/regex.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 // mediaExtensions is a set of known media file extensions (lowercase, without dot)
@@ -54,6 +55,18 @@ func RemoveExtension(value string) string {
 		}
 	}
 	return value
+}
+
+// IsUsableName reports whether name can serve as a filesystem path component
+// without collapsing. A name that is empty, or made up only of dots and
+// whitespace (e.g. "", ".", "..", "   "), makes filepath.Join(dir, name)
+// resolve to dir itself or a parent — never a safe download/symlink target.
+// Names with at least one meaningful rune (including "multi   space" release
+// names and dotfiles like ".hidden") are usable.
+func IsUsableName(name string) bool {
+	return strings.TrimFunc(name, func(r rune) bool {
+		return r == '.' || unicode.IsSpace(r)
+	}) != ""
 }
 
 func IsMediaFile(path string) bool {

--- a/internal/utils/regex_test.go
+++ b/internal/utils/regex_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import "testing"
+
+func TestIsUsableName(t *testing.T) {
+	usable := []string{
+		"Movie",
+		"Great.Movie.2024",
+		".hidden",                      // dotfile: has a meaningful rune
+		"www.UIndex.org    Some.Movie", // multi-space release name is legitimate
+		"..b",                          // leading dots are fine when a real rune follows
+		"a",
+	}
+	for _, name := range usable {
+		if !IsUsableName(name) {
+			t.Errorf("IsUsableName(%q) = false, want true", name)
+		}
+	}
+
+	unusable := []string{
+		"",    // empty
+		".",   // filepath.Join(dir, ".") == dir
+		"..",  // parent traversal
+		"...", // collapses under Clean
+		"   ", // whitespace only
+		" . ", // dots + whitespace only
+		". .", // dots + whitespace only
+		"\t",  // tab only
+	}
+	for _, name := range unusable {
+		if IsUsableName(name) {
+			t.Errorf("IsUsableName(%q) = true, want false", name)
+		}
+	}
+}

--- a/pkg/manager/download_path_guard_test.go
+++ b/pkg/manager/download_path_guard_test.go
@@ -1,0 +1,73 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/storage"
+)
+
+// TestDeleteEntryFilesRefusesCategoryDir is the production repro: an entry whose
+// Name is empty (or ".") makes DownloadPath() collapse onto the category
+// SavePath. The guard must refuse to RemoveAll that shared directory, leaving
+// every sibling entry's data — and the sibling category dirs — intact.
+// A valid Name must still remove only its own child directory.
+func TestDeleteEntryFilesRefusesCategoryDir(t *testing.T) {
+	config.Reset()
+	config.SetConfigPath(t.TempDir())
+	t.Cleanup(config.Reset)
+
+	store, err := storage.NewStorage(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	q := newQueue(store, "")
+	q.logger = zerolog.Nop()
+
+	downloads := t.TempDir()
+	radarr := filepath.Join(downloads, "radarr")
+	sonarr := filepath.Join(downloads, "sonarr")
+	sibling := filepath.Join(radarr, "OtherMovie") // another entry's symlink dir
+	for _, d := range []string{radarr, sonarr, sibling} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", d, err)
+		}
+	}
+	siblingFile := filepath.Join(sibling, "video.mkv")
+	if err := os.WriteFile(siblingFile, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Empty Name: DownloadPath() collapses to the category dir itself.
+	empty := &storage.Entry{Protocol: config.ProtocolTorrent, InfoHash: "empty-name-hash", Name: "", SavePath: radarr}
+	if filepath.Clean(empty.DownloadPath()) != filepath.Clean(radarr) {
+		t.Fatalf("precondition: empty-name DownloadPath %q must equal SavePath %q", empty.DownloadPath(), radarr)
+	}
+	q.deleteEntryFiles(empty)
+	for _, p := range []string{radarr, sonarr, sibling, siblingFile} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("empty-name delete destroyed %q: %v", p, err)
+		}
+	}
+
+	// "." Name collapses the same way and must also be refused.
+	dot := &storage.Entry{Protocol: config.ProtocolTorrent, InfoHash: "dot-name-hash", Name: ".", SavePath: radarr}
+	q.deleteEntryFiles(dot)
+	if _, err := os.Stat(radarr); err != nil {
+		t.Fatalf(`"." delete destroyed the category dir: %v`, err)
+	}
+
+	// Control: a valid Name removes only its own child, never the category dir.
+	valid := &storage.Entry{Protocol: config.ProtocolTorrent, InfoHash: "valid-hash", Name: "OtherMovie", SavePath: radarr}
+	q.deleteEntryFiles(valid)
+	if _, err := os.Stat(sibling); !os.IsNotExist(err) {
+		t.Fatalf("valid-name delete failed to remove its own child dir (stat err=%v)", err)
+	}
+	if _, err := os.Stat(radarr); err != nil {
+		t.Fatalf("valid-name delete wrongly removed the category dir: %v", err)
+	}
+}

--- a/pkg/manager/queue.go
+++ b/pkg/manager/queue.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"cmp"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -117,6 +118,23 @@ func (q *Queue) deleteEntryFiles(entry *storage.Entry) {
 	}
 	downloadedPath := entry.DownloadPath()
 	if downloadedPath == "" {
+		return
+	}
+	// An empty or collapsed Name makes DownloadPath() resolve to the category
+	// SavePath itself (or a parent of it): filepath.Join(SavePath, "") and
+	// Join(SavePath, ".") both clean back to SavePath. RemoveAll on that would
+	// destroy every sibling entry's symlinks in the same category directory.
+	// Refuse and log loudly instead of deleting a shared directory.
+	cleanDL := filepath.Clean(downloadedPath)
+	cleanSave := filepath.Clean(entry.SavePath)
+	if cleanDL == cleanSave || cleanDL == "." || cleanDL == string(os.PathSeparator) ||
+		!strings.HasPrefix(cleanDL+string(os.PathSeparator), cleanSave+string(os.PathSeparator)) {
+		q.logger.Error().
+			Str("path", downloadedPath).
+			Str("save_path", entry.SavePath).
+			Str("infohash", entry.InfoHash).
+			Str("name", entry.Name).
+			Msg("Refusing to delete download path at or above SavePath; removing it would destroy sibling entries")
 		return
 	}
 	if err := os.RemoveAll(downloadedPath); err != nil {

--- a/pkg/usenet/parser/misc.go
+++ b/pkg/usenet/parser/misc.go
@@ -78,15 +78,22 @@ func getGroupsList(groups map[string]struct{}) []string {
 }
 
 func determineNZBName(filename string, meta map[string]string) string {
-	// Prefer filename if it exists
-	if filename != "" {
-		filename = strings.TrimSuffix(filename, filepath.Ext(filename))
-	} else if name := meta["Name"]; name != "" {
-		filename = name
-	} else if title := meta["title"]; title != "" {
-		filename = title
+	// Try each name source in priority order and return the first that survives
+	// invalid-char removal as a usable (non-collapsing) path component. A source
+	// that cleans to nothing — ".nzb", "???.nzb", "***.nzb", "" — must NOT
+	// shadow a usable meta fallback: an empty name makes DownloadPath() collapse
+	// onto the category SavePath, which the deletion path would then wipe. When
+	// no source is usable the caller substitutes the unique NZB ID.
+	for _, candidate := range []string{
+		strings.TrimSuffix(filename, filepath.Ext(filename)),
+		meta["Name"],
+		meta["title"],
+	} {
+		if cleaned := utils.RemoveInvalidChars(candidate); utils.IsUsableName(cleaned) {
+			return cleaned
+		}
 	}
-	return utils.RemoveInvalidChars(filename)
+	return ""
 }
 
 func determineExtension(group *FileGroup) string {

--- a/pkg/usenet/parser/name_test.go
+++ b/pkg/usenet/parser/name_test.go
@@ -1,0 +1,32 @@
+package parser
+
+import "testing"
+
+// determineNZBName must never return an unusable (collapsing) name when a
+// usable source is available, and must return "" only when every source
+// collapses — so Parse can substitute the unique NZB ID.
+func TestDetermineNZBName(t *testing.T) {
+	cases := []struct {
+		name     string
+		filename string
+		meta     map[string]string
+		want     string
+	}{
+		{"valid filename strips ext", "Great.Movie.2024.nzb", nil, "Great.Movie.2024"},
+		{"empty filename, no meta", "", nil, ""},
+		{"bare extension collapses", ".nzb", nil, ""},
+		{"all invalid chars collapse", "???.nzb", nil, ""},
+		{"stars collapse", "***.nzb", nil, ""},
+		{"collapsing filename falls back to meta Name", "???.nzb", map[string]string{"Name": "Fallback Movie"}, "Fallback Movie"},
+		{"collapsing filename falls back to title", "***.nzb", map[string]string{"title": "Title Movie"}, "Title Movie"},
+		{"meta Name preferred over title", "", map[string]string{"Name": "By Name", "title": "By Title"}, "By Name"},
+		{"multi-space release name preserved", "www.UIndex.org    Some.Movie.mkv", nil, "www.UIndex.org    Some.Movie"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := determineNZBName(tc.filename, tc.meta); got != tc.want {
+				t.Fatalf("determineNZBName(%q, %v) = %q, want %q", tc.filename, tc.meta, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/usenet/parser/parser.go
+++ b/pkg/usenet/parser/parser.go
@@ -170,6 +170,16 @@ func (p *NZBParser) Parse(ctx context.Context, filename string, content []byte) 
 	}
 
 	nzb.ID = uuid.New().String()
+	if !utils.IsUsableName(nzb.Name) {
+		// No source (filename, meta Name/title) yielded a usable name. Fall back
+		// to the unique, filesystem-safe NZB ID so the derived DownloadPath()
+		// cannot collapse onto the category directory.
+		p.logger.Warn().
+			Str("nzb_id", nzb.ID).
+			Str("filename", filename).
+			Msg("NZB has no usable name; substituting the NZB ID to keep the download path unique")
+		nzb.Name = nzb.ID
+	}
 	return nzb, fileGroups, nil
 }
 


### PR DESCRIPTION
**What breaks:** deleting a single entry can delete every download under its category. We lost 2,571 completed entries in one night across `downloads/radarr` and `downloads/sonarr`.

**Why:** `Entry.DownloadPath()` is `filepath.Join(SavePath, RemoveExtension(Name))`. For an *arr entry `SavePath` is the category directory, so an entry whose `Name` is empty (or `.`) makes `DownloadPath()` clean back to `SavePath` itself. `Queue.deleteEntryFiles` in `pkg/manager/queue.go` only guarded `downloadedPath == ""`, so `os.RemoveAll` then ran on the category directory and took every sibling entry's symlinks with it.

Empty names are reachable: `determineNZBName` in `pkg/usenet/parser/misc.go` strips the extension and invalid characters with no fallback, so `.nzb`, `???.nzb`, `***.nzb`, or an all-invalid title all yield `""` — and a source that cleans to nothing shadows a usable `meta["Name"]`/`meta["title"]`.

**The fix:** two commits. `deleteEntryFiles` refuses any path that is not strictly a descendant of `SavePath` and logs the refusal. `determineNZBName` returns the first source that survives as a usable path component, and `Parse` substitutes the unique NZB ID when none is.

**Evidence:** running in production on a ~47,000-entry library. Tests in `pkg/manager`, `pkg/usenet/parser`, and `internal/utils` all fail on `beta` without the change.
