### PR TITLE
fix(server): don't overwrite shared *arr host/token on empty-credential polls

### DIFF
--- a/pkg/server/qbit/auth_test.go
+++ b/pkg/server/qbit/auth_test.go
@@ -1,0 +1,100 @@
+package qbit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/arr"
+	"github.com/sirrobot01/decypharr/pkg/manager"
+)
+
+func newQBitTestManager(t *testing.T) *manager.Manager {
+	t.Helper()
+	config.Reset()
+	config.SetConfigPath(t.TempDir())
+	t.Cleanup(config.Reset)
+	config.Get().UseAuth = false
+	m := manager.New()
+	t.Cleanup(func() {
+		if err := m.Stop(); err != nil {
+			t.Errorf("Stop manager: %v", err)
+		}
+	})
+	return m
+}
+
+// healthOKServer answers 200 to the arr health probe so Arr.Validate()
+// completes quickly and deterministically, without any real network
+// dependency, when authenticate runs its validation pass.
+func healthOKServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestAuthenticateDoesNotWipeAutoArrOnEmptyCredentials is the regression guard
+// for the shared-arr corruption bug. When Sonarr/Radarr poll GET /torrents/info
+// with blank download-client credentials, authenticate must NOT overwrite an
+// already-populated auto arr's Host/Token with empty strings.
+//
+// Pre-fix, the unconditional `if a.Source == "auto" { a.Host = username;
+// a.Token = password }` wiped Host/Token to "" on every empty-cred poll,
+// corrupting the shared arr map that other consumers rely on — notably the
+// repair service, which then rejects the arr with "arr not configured".
+func TestAuthenticateDoesNotWipeAutoArrOnEmptyCredentials(t *testing.T) {
+	srv := healthOKServer(t)
+	m := newQBitTestManager(t)
+
+	const category = "sonarr"
+	seeded := arr.New(category, srv.URL, "seed-token", false, nil, "", string(arr.SourceAuto))
+	m.Arr().AddOrUpdate(seeded)
+
+	q := New(m)
+	got, err := q.authenticate(category, "", "")
+	if err != nil {
+		t.Fatalf("authenticate with empty creds returned error: %v", err)
+	}
+	if got.Host != srv.URL {
+		t.Fatalf("Host wiped by empty-cred poll: got %q, want %q", got.Host, srv.URL)
+	}
+	if got.Token != "seed-token" {
+		t.Fatalf("Token wiped by empty-cred poll: got %q, want %q", got.Token, "seed-token")
+	}
+
+	// The shared map entry every other consumer reads must stay intact.
+	shared := m.Arr().Get(category)
+	if shared == nil {
+		t.Fatalf("shared arr disappeared from the map")
+	}
+	if shared.Host != srv.URL || shared.Token != "seed-token" {
+		t.Fatalf("shared arr corrupted: Host=%q Token=%q", shared.Host, shared.Token)
+	}
+}
+
+// TestAuthenticatePopulatesAutoArrWithValidCredentials proves the legitimate
+// path is unchanged: a poll carrying valid credentials still populates an auto
+// arr's Host/Token and registers it in the shared map.
+func TestAuthenticatePopulatesAutoArrWithValidCredentials(t *testing.T) {
+	srv := healthOKServer(t)
+	m := newQBitTestManager(t)
+
+	const category = "radarr"
+	q := New(m)
+	got, err := q.authenticate(category, srv.URL, "valid-token")
+	if err != nil {
+		t.Fatalf("authenticate with valid creds returned error: %v", err)
+	}
+	if got.Host != srv.URL || got.Token != "valid-token" {
+		t.Fatalf("auto arr not populated: got Host=%q Token=%q", got.Host, got.Token)
+	}
+
+	shared := m.Arr().Get(category)
+	if shared == nil || shared.Host != srv.URL || shared.Token != "valid-token" {
+		t.Fatalf("valid creds not registered in shared map: %+v", shared)
+	}
+}

--- a/pkg/server/qbit/context.go
+++ b/pkg/server/qbit/context.go
@@ -162,7 +162,7 @@ func (q *QBit) authenticate(category, username, password string) (*arr.Arr, erro
 	if (username == "" || password == "") && cfg.UseAuth {
 		return nil, fmt.Errorf("unauthorized: Host and token are required for authentication(you've enabled authentication)")
 	}
-	if a.Source == "auto" {
+	if a.Source == "auto" && username != "" && password != "" {
 		a.Host = username
 		a.Token = password
 	}

--- a/pkg/server/sabnzbd/context.go
+++ b/pkg/server/sabnzbd/context.go
@@ -123,7 +123,7 @@ func (s *SABnzbd) authenticate(category, username, password string) (*arr.Arr, e
 	if (username == "" || password == "") && cfg.UseAuth {
 		return nil, fmt.Errorf("unauthorized: Host and token are required for authentication(you've enabled authentication)")
 	}
-	if a.Source == "auto" {
+	if a.Source == "auto" && username != "" && password != "" {
 		a.Host = username
 		a.Token = password
 	}

--- a/pkg/server/sabnzbd/context_test.go
+++ b/pkg/server/sabnzbd/context_test.go
@@ -1,0 +1,93 @@
+package sabnzbd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/arr"
+	"github.com/sirrobot01/decypharr/pkg/manager"
+)
+
+// newSABAuthHarness wires a bare Manager into the SABnzbd shim. The auth path
+// never touches usenet — it only reads and mutates the shared arr map.
+func newSABAuthHarness(t *testing.T) (*SABnzbd, *manager.Manager) {
+	t.Helper()
+	config.Reset()
+	config.SetConfigPath(t.TempDir())
+	t.Cleanup(config.Reset)
+	config.Get().UseAuth = false
+	m := manager.New()
+	t.Cleanup(func() {
+		if err := m.Stop(); err != nil {
+			t.Errorf("Stop manager: %v", err)
+		}
+	})
+	return New(m), m
+}
+
+// sabHealthOKServer answers 200 to the arr health probe so Arr.Validate()
+// completes quickly and deterministically during authenticate.
+func sabHealthOKServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestAuthenticateDoesNotWipeAutoArrOnEmptyCredentials is the SABnzbd-side
+// regression guard for the shared-arr corruption bug. A SAB poll with empty
+// ma_username/ma_password must NOT wipe an already-populated auto arr's
+// Host/Token, which would corrupt the shared arr map for every other consumer.
+func TestAuthenticateDoesNotWipeAutoArrOnEmptyCredentials(t *testing.T) {
+	srv := sabHealthOKServer(t)
+	s, m := newSABAuthHarness(t)
+
+	const category = "sonarr"
+	seeded := arr.New(category, srv.URL, "seed-token", false, nil, "", string(arr.SourceAuto))
+	m.Arr().AddOrUpdate(seeded)
+
+	got, err := s.authenticate(category, "", "")
+	if err != nil {
+		t.Fatalf("authenticate with empty creds returned error: %v", err)
+	}
+	if got.Host != srv.URL {
+		t.Fatalf("Host wiped by empty-cred poll: got %q, want %q", got.Host, srv.URL)
+	}
+	if got.Token != "seed-token" {
+		t.Fatalf("Token wiped by empty-cred poll: got %q, want %q", got.Token, "seed-token")
+	}
+
+	shared := m.Arr().Get(category)
+	if shared == nil {
+		t.Fatalf("shared arr disappeared from the map")
+	}
+	if shared.Host != srv.URL || shared.Token != "seed-token" {
+		t.Fatalf("shared arr corrupted: Host=%q Token=%q", shared.Host, shared.Token)
+	}
+}
+
+// TestAuthenticatePopulatesAutoArrWithValidCredentials proves the legitimate
+// path is unchanged: a poll carrying valid credentials still populates an auto
+// arr's Host/Token and registers it in the shared map.
+func TestAuthenticatePopulatesAutoArrWithValidCredentials(t *testing.T) {
+	srv := sabHealthOKServer(t)
+	s, m := newSABAuthHarness(t)
+
+	const category = "radarr"
+	got, err := s.authenticate(category, srv.URL, "valid-token")
+	if err != nil {
+		t.Fatalf("authenticate with valid creds returned error: %v", err)
+	}
+	if got.Host != srv.URL || got.Token != "valid-token" {
+		t.Fatalf("auto arr not populated: got Host=%q Token=%q", got.Host, got.Token)
+	}
+
+	shared := m.Arr().Get(category)
+	if shared == nil || shared.Host != srv.URL || shared.Token != "valid-token" {
+		t.Fatalf("valid creds not registered in shared map: %+v", shared)
+	}
+}


### PR DESCRIPTION
**What breaks:** after Sonarr/Radarr have been polling for a while, every *arr starts reporting "arr not configured" until its host/token is re-saved in the UI. Repair sweeps fail for the same reason.

**Why:** `authenticate` in `pkg/server/qbit/context.go` and `pkg/server/sabnzbd/context.go` overwrites the shared `*arr.Arr`'s `Host`/`Token` in place whenever `a.Source == "auto"`, unconditionally. A poll that arrives with blank download-client credentials therefore sets them to `""`. Because the `*arr.Arr` is shared through the manager's arr map, that corrupts the entry for every other consumer, not just the polling request. The functions already apply an empty-credential guard a few lines lower, before `AddOrUpdate` — the in-place mutation just isn't covered by it.

**The fix:** only adopt credentials from a poll when both `username` and `password` are non-empty. A poll with valid credentials still populates or updates an auto arr; an empty-credential poll no longer wipes one.

**Evidence:** running in production on a ~47,000-entry library. Regression and positive tests added to both packages; the regression tests fail on `beta` without the change.
