### PR TITLE
fix(config): persist an explicit debrids[].download_uncached=false

### DIFF
--- a/internal/config/debrid.go
+++ b/internal/config/debrid.go
@@ -11,7 +11,7 @@ type Debrid struct {
 	Name                         string   `json:"name,omitempty"`
 	APIKey                       string   `json:"api_key,omitempty"`
 	DownloadAPIKeys              []string `json:"download_api_keys,omitempty"`
-	DownloadUncached             bool     `json:"download_uncached,omitempty"`
+	DownloadUncached             *bool    `json:"download_uncached,omitempty"`
 	RateLimit                    string   `json:"rate_limit,omitempty"` // 200/minute or 10/second
 	RepairRateLimit              string   `json:"repair_rate_limit,omitempty"`
 	DownloadRateLimit            string   `json:"download_rate_limit,omitempty"`
@@ -35,6 +35,15 @@ type Debrid struct {
 
 	// Directories
 	Directories map[string]WebdavDirectories `json:"directories,omitempty"` // Deprecated. Use global setting instead.
+}
+
+// DownloadsUncached resolves the tri-state download_uncached setting. A nil
+// value means the key is absent from config.json and keeps the historical
+// default: false (only cached torrents may be imported). Explicit true/false
+// values are persisted as-is; the field is *bool so an explicit false survives
+// a save round-trip instead of being stripped by omitempty.
+func (d Debrid) DownloadsUncached() bool {
+	return d.DownloadUncached != nil && *d.DownloadUncached
 }
 
 func (c *Config) updateDebrid(d Debrid) Debrid {

--- a/internal/config/debrid_test.go
+++ b/internal/config/debrid_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	json "github.com/bytedance/sonic"
+)
+
+func boolPtr(value bool) *bool { return &value }
+
+// TestDebridDownloadUncachedSaveRoundTrip reproduces the bug where
+// POST /api/config with debrids[].download_uncached=false returned 200 but the
+// key was stripped from disk (bool + omitempty), and any later save re-stripped
+// a hand-edited false. With *bool, explicit values survive save round-trips
+// while an absent key stays absent and resolves to the historical default
+// (false).
+func TestDebridDownloadUncachedSaveRoundTrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		fragment   string // JSON inside the debrid object, "" = key absent
+		wantOnDisk bool
+		want       *bool
+	}{
+		{name: "explicit false persists", fragment: `"download_uncached":false,`, wantOnDisk: true, want: boolPtr(false)},
+		{name: "explicit true persists", fragment: `"download_uncached":true,`, wantOnDisk: true, want: boolPtr(true)},
+		{name: "absent stays absent", fragment: ``, wantOnDisk: false, want: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Reset()
+			SetConfigPath(t.TempDir())
+			t.Cleanup(Reset)
+
+			// Simulate the API handler's decode of a POST body.
+			body := `{"debrids":[{"name":"rd","provider":"realdebrid","api_key":"secret",` +
+				test.fragment + `"rate_limit":"250/minute"}]}`
+			var cfg Config
+			if err := json.Unmarshal([]byte(body), &cfg); err != nil {
+				t.Fatalf("unmarshal POST body: %v", err)
+			}
+			if err := cfg.Save(); err != nil {
+				t.Fatalf("save config: %v", err)
+			}
+
+			verify := func(step string) {
+				data, err := os.ReadFile(cfg.JsonFile())
+				if err != nil {
+					t.Fatalf("%s: read config file: %v", step, err)
+				}
+				if got := strings.Contains(string(data), `"download_uncached"`); got != test.wantOnDisk {
+					t.Fatalf("%s: download_uncached key on disk = %v, want %v: %s", step, got, test.wantOnDisk, data)
+				}
+			}
+			verify("first save")
+
+			// Reload the persisted file the way loadConfig does (decode +
+			// defaults) and confirm the tri-state value and its resolution.
+			data, err := os.ReadFile(cfg.JsonFile())
+			if err != nil {
+				t.Fatalf("read config file: %v", err)
+			}
+			var loaded Config
+			if err := json.Unmarshal(data, &loaded); err != nil {
+				t.Fatalf("unmarshal persisted config: %v", err)
+			}
+			loaded.setDefaults()
+			if len(loaded.Debrids) != 1 {
+				t.Fatalf("expected 1 debrid after reload, got %d", len(loaded.Debrids))
+			}
+			got := loaded.Debrids[0].DownloadUncached
+			switch {
+			case test.want == nil && got != nil:
+				t.Fatalf("expected nil DownloadUncached after reload, got %v", *got)
+			case test.want != nil && (got == nil || *got != *test.want):
+				t.Fatalf("DownloadUncached after reload = %v, want %v", got, *test.want)
+			}
+			wantEffective := test.want != nil && *test.want
+			if loaded.Debrids[0].DownloadsUncached() != wantEffective {
+				t.Fatalf("DownloadsUncached() = %v, want %v", loaded.Debrids[0].DownloadsUncached(), wantEffective)
+			}
+
+			// A later save (the re-strip path) must not change the on-disk
+			// representation of the key.
+			if err := loaded.Save(); err != nil {
+				t.Fatalf("re-save config: %v", err)
+			}
+			verify("re-save")
+		})
+	}
+}

--- a/pkg/debrid/providers/debridlink/debrid_link.go
+++ b/pkg/debrid/providers/debridlink/debrid_link.go
@@ -76,7 +76,7 @@ func New(dc config.Debrid, ratelimits map[string]ratelimit.Limiter) (*DebridLink
 		Host:                  "https://debrid-link.com/api/v2",
 		APIKey:                dc.APIKey,
 		accountsManager:       account.NewManager(dc, ratelimits["download"], log),
-		DownloadUncached:      dc.DownloadUncached,
+		DownloadUncached:      dc.DownloadsUncached(),
 		autoExpiresLinksAfter: autoExpiresLinksAfter,
 		client:                request.New(opts...),
 		repairClient:          request.New(repairOpts...),

--- a/pkg/manager/processor.go
+++ b/pkg/manager/processor.go
@@ -427,7 +427,7 @@ func (m *Manager) SendToDebrid(ctx context.Context, importRequest *ImportRequest
 		if importRequest.DownloadUncached != nil {
 			overrideDownloadUncached = *importRequest.DownloadUncached
 		} else {
-			overrideDownloadUncached = db.Config().DownloadUncached
+			overrideDownloadUncached = db.Config().DownloadsUncached()
 		}
 		debridTorrent.DownloadUncached = overrideDownloadUncached
 		_logger := db.Logger()

--- a/pkg/server/setup.go
+++ b/pkg/server/setup.go
@@ -175,12 +175,12 @@ func (s *Server) setupCompleteHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		debrid := config.Debrid{
-			Provider:         req.Debrid.Provider,
-			Name:             req.Debrid.Provider,
-			APIKey:           req.Debrid.APIKey,
-			DownloadAPIKeys:  []string{req.Debrid.APIKey},
-			DownloadUncached: false,
-			RateLimit:        config.DefaultRateLimit,
+			Provider:        req.Debrid.Provider,
+			Name:            req.Debrid.Provider,
+			APIKey:          req.Debrid.APIKey,
+			DownloadAPIKeys: []string{req.Debrid.APIKey},
+			// DownloadUncached left nil: absent means the default (false).
+			RateLimit: config.DefaultRateLimit,
 		}
 
 		if len(cfg.Debrids) == 0 {


### PR DESCRIPTION
**What breaks:** `debrids[].download_uncached` cannot be turned off. `POST /api/config` with `download_uncached: false` returns 200, but the key never reaches `config.json`, and a hand-edited `false` is stripped again by the next save. The setting always reverts to the default.

**Why:** the field is `bool` with `omitempty` in `internal/config/debrid.go`, so an explicit `false` is indistinguishable from an absent key at marshal time and is simply dropped.

**The fix:** make it `*bool` (nil = absent = the historical default, false) with a `Debrid.DownloadsUncached()` accessor for the three call sites that read it. The Arr-level `download_uncached` already uses this pattern; the debrid level now matches it.

**Evidence:** running in production on a ~47,000-entry library. `TestDebridDownloadUncachedSaveRoundTrip` covers explicit false / explicit true / absent, including the re-save path, and fails on `beta` without the change.

Split out of a second config-API fix (partial POSTs clearing omitted sections) so each is reviewable on its own; the two are independent.
