### PR TITLE
fix(config): stop a partial POST /api/config from clearing omitted sections

### DIFF
--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+
+	json "github.com/bytedance/sonic"
+)
+
+// PreserveMissingSections restores, from src, every top-level configuration
+// field whose JSON key is absent from the posted body. It is the merge step
+// behind POST /api/config: that handler decodes the body into a zero Config,
+// so any top-level section the caller omitted would otherwise become its zero
+// value and the subsequent Save would erase it from disk (a partial POST
+// without "debrids" wiped every configured provider, api keys included).
+//
+// Key presence is what separates "leave it alone" from "clear it": a key
+// absent from body keeps the current value, while an explicitly posted empty
+// value (`"debrids": []`, `"download_folder": ""`) still overwrites. Bodies
+// that post every key (the web UI's full-config save) are unaffected because
+// nothing is missing.
+//
+// Fields tagged `json:"-"` (e.g. Auth) are never copied here; the API handler
+// manages those explicitly. Key matching is case-insensitive to mirror the
+// JSON decoder's field matching.
+func (c *Config) PreserveMissingSections(src *Config, body []byte) error {
+	var posted map[string]any
+	if err := json.Unmarshal(body, &posted); err != nil {
+		return err
+	}
+	present := make(map[string]struct{}, len(posted))
+	for key := range posted {
+		present[strings.ToLower(key)] = struct{}{}
+	}
+
+	dst := reflect.ValueOf(c).Elem()
+	from := reflect.ValueOf(src).Elem()
+	for i, t := 0, dst.Type(); i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		if _, ok := present[strings.ToLower(name)]; ok {
+			continue
+		}
+		dst.Field(i).Set(from.Field(i))
+	}
+	return nil
+}

--- a/internal/config/update_test.go
+++ b/internal/config/update_test.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	json "github.com/bytedance/sonic"
+)
+
+func preserveBaseConfig() *Config {
+	return &Config{
+		LogLevel:       "info",
+		Port:           "8282",
+		DownloadFolder: "/downloads",
+		Debrids: []Debrid{
+			{Name: "rd", Provider: "realdebrid", APIKey: "rd-key"},
+			{Name: "tb", Provider: "torbox", APIKey: "tb-key"},
+		},
+		Arrs:   []Arr{{Name: "radarr", Host: "http://radarr:7878", Token: "tok"}},
+		Usenet: Usenet{Providers: []UsenetProvider{{Host: "news.example", Username: "u", Password: "p"}}},
+	}
+}
+
+// TestPreserveMissingSectionsKeepsOmittedSections covers the data loss: a POST
+// without the "debrids" key must not wipe configured providers (api keys
+// included) or any other omitted section.
+func TestPreserveMissingSectionsKeepsOmittedSections(t *testing.T) {
+	current := preserveBaseConfig()
+	body := []byte(`{"log_level":"debug"}`)
+
+	var updated Config
+	if err := json.Unmarshal(body, &updated); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if err := updated.PreserveMissingSections(current, body); err != nil {
+		t.Fatalf("PreserveMissingSections: %v", err)
+	}
+
+	if updated.LogLevel != "debug" {
+		t.Fatalf("posted log_level lost: %q", updated.LogLevel)
+	}
+	if len(updated.Debrids) != 2 || updated.Debrids[0].APIKey != "rd-key" || updated.Debrids[1].APIKey != "tb-key" {
+		t.Fatalf("omitted debrids section was not preserved: %+v", updated.Debrids)
+	}
+	if len(updated.Arrs) != 1 || updated.Arrs[0].Token != "tok" {
+		t.Fatalf("omitted arrs section was not preserved: %+v", updated.Arrs)
+	}
+	if len(updated.Usenet.Providers) != 1 {
+		t.Fatalf("omitted usenet section was not preserved: %+v", updated.Usenet)
+	}
+	if updated.DownloadFolder != "/downloads" || updated.Port != "8282" {
+		t.Fatalf("omitted scalar fields were not preserved: folder=%q port=%q", updated.DownloadFolder, updated.Port)
+	}
+}
+
+// TestPreserveMissingSectionsExplicitEmptyStillClears: presence of the key,
+// even with an empty value, means the caller wants that value.
+func TestPreserveMissingSectionsExplicitEmptyStillClears(t *testing.T) {
+	current := preserveBaseConfig()
+	body := []byte(`{"debrids":[],"download_folder":""}`)
+
+	var updated Config
+	if err := json.Unmarshal(body, &updated); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if err := updated.PreserveMissingSections(current, body); err != nil {
+		t.Fatalf("PreserveMissingSections: %v", err)
+	}
+
+	if len(updated.Debrids) != 0 {
+		t.Fatalf("explicitly posted empty debrids must clear, got %+v", updated.Debrids)
+	}
+	if updated.DownloadFolder != "" {
+		t.Fatalf("explicitly posted empty download_folder must clear, got %q", updated.DownloadFolder)
+	}
+	if len(updated.Arrs) != 1 {
+		t.Fatalf("omitted arrs must be preserved, got %+v", updated.Arrs)
+	}
+}
+
+// TestPreserveMissingSectionsFullPostUnchanged: a body that posts every
+// top-level key (the web UI's full-config save) must decode identically with
+// and without the merge step.
+func TestPreserveMissingSectionsFullPostUnchanged(t *testing.T) {
+	current := preserveBaseConfig()
+	body := []byte(`{
+		"log_level": "trace",
+		"url_base": "/",
+		"bind_address": "127.0.0.1",
+		"app_url": "http://app.example",
+		"port": "9999",
+		"allowed_file_types": ["mkv"],
+		"min_file_size": "1MB",
+		"max_file_size": "10GB",
+		"remove_stalled_after": "10m",
+		"nzb_user_agent": "agent",
+		"download_folder": "/new-downloads",
+		"refresh_interval": "30s",
+		"default_download_action": "symlink",
+		"max_active_downloads": 7,
+		"skip_pre_cache": true,
+		"always_rm_tracker_urls": true,
+		"folder_naming": "original",
+		"disable_webdav": true,
+		"refresh_dirs": "/dirs",
+		"custom_folders": {},
+		"debrids": [{"name": "new", "provider": "realdebrid", "api_key": "new-key"}],
+		"arrs": [],
+		"queue_cleanup": {"rules": []},
+		"mount": {"type": "none", "mount_path": "/mnt"},
+		"usenet": {"providers": []},
+		"notifications": {"enabled": false},
+		"repair": {"enabled": false}
+	}`)
+
+	var plain, merged Config
+	if err := json.Unmarshal(body, &plain); err != nil {
+		t.Fatalf("unmarshal body (plain): %v", err)
+	}
+	if err := json.Unmarshal(body, &merged); err != nil {
+		t.Fatalf("unmarshal body (merged): %v", err)
+	}
+	if err := merged.PreserveMissingSections(current, body); err != nil {
+		t.Fatalf("PreserveMissingSections: %v", err)
+	}
+	if !reflect.DeepEqual(plain, merged) {
+		t.Fatalf("full-config POST changed by merge:\nplain:  %+v\nmerged: %+v", plain, merged)
+	}
+	if len(merged.Debrids) != 1 || merged.Debrids[0].APIKey != "new-key" {
+		t.Fatalf("posted debrids did not win wholesale: %+v", merged.Debrids)
+	}
+	if len(merged.Arrs) != 0 {
+		t.Fatalf("posted empty arrs did not clear: %+v", merged.Arrs)
+	}
+}

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -502,9 +502,27 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	// Decode the incoming config update
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to read config update request")
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
 	var newConfig config.Config
-	if err := json.ConfigDefault.NewDecoder(r.Body).Decode(&newConfig); err != nil {
+	if err := json.Unmarshal(body, &newConfig); err != nil {
 		s.logger.Error().Err(err).Msg("Failed to decode config update request")
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	currentConfig := config.Get()
+
+	// A top-level key absent from the posted JSON means "keep the current
+	// value"; only explicitly posted values (including empty ones such as
+	// "debrids": []) overwrite. Without this merge, a partial POST replaced
+	// every omitted section with its zero value and Save wiped it from disk.
+	if err := newConfig.PreserveMissingSections(currentConfig, body); err != nil {
+		s.logger.Error().Err(err).Msg("Failed to merge config update request")
 		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -518,7 +536,6 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Preserve fields that shouldn't be overwritten by frontend
-	currentConfig := config.Get()
 	newConfig.Auth = currentConfig.GetAuth()
 	// The frontend config form doesn't include use_auth or enable_webdav_auth,
 	// so they would be zero-valued (false) in the decoded payload. Preserve

--- a/pkg/server/config_update_api_test.go
+++ b/pkg/server/config_update_api_test.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	json "github.com/bytedance/sonic"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/manager"
+)
+
+// apiTestConfigJSON mirrors the production shape that was lost: two configured
+// providers with api keys, plus an arr.
+const apiTestConfigJSON = `{
+  "log_level": "info",
+  "download_folder": "/downloads",
+  "debrids": [
+    {"name": "rd", "provider": "realdebrid", "api_key": "rd-key"},
+    {"name": "tb", "provider": "torbox", "api_key": "tb-key"}
+  ],
+  "arrs": [{"name": "radarr", "host": "http://radarr:7878", "token": "tok"}]
+}`
+
+// setupConfigAPITest seeds a config.json fixture and returns a Server wired to
+// a real Manager (handleUpdateConfig calls s.manager.Arr()).
+func setupConfigAPITest(t *testing.T) (*Server, string) {
+	t.Helper()
+	config.Reset()
+	t.Cleanup(config.Reset)
+	dir := t.TempDir()
+	config.SetConfigPath(dir)
+	cfgFile := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfgFile, []byte(apiTestConfigJSON), 0644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+	if cfg := config.Get(); len(cfg.Debrids) != 2 {
+		t.Fatalf("fixture did not load: %+v", cfg.Debrids)
+	}
+	m := manager.New()
+	t.Cleanup(func() {
+		if err := m.Stop(); err != nil {
+			t.Errorf("Stop manager: %v", err)
+		}
+	})
+	return &Server{manager: m}, cfgFile
+}
+
+func postConfigUpdate(t *testing.T, s *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleUpdateConfig(rec, req)
+	return rec
+}
+
+func readSavedConfig(t *testing.T, cfgFile string) config.Config {
+	t.Helper()
+	data, err := os.ReadFile(cfgFile)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	var saved config.Config
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("unmarshal saved config: %v", err)
+	}
+	return saved
+}
+
+// TestHandleUpdateConfigPartialPostPreservesSections reproduces the incident:
+// a POST without the "debrids" key must not wipe the configured providers
+// (api keys included) from disk.
+func TestHandleUpdateConfigPartialPostPreservesSections(t *testing.T) {
+	s, cfgFile := setupConfigAPITest(t)
+
+	rec := postConfigUpdate(t, s, `{"log_level":"debug"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	saved := readSavedConfig(t, cfgFile)
+	if saved.LogLevel != "debug" {
+		t.Fatalf("posted log_level not applied: %q", saved.LogLevel)
+	}
+	if len(saved.Debrids) != 2 {
+		t.Fatalf("partial POST wiped debrid providers: %+v", saved.Debrids)
+	}
+	if saved.Debrids[0].APIKey != "rd-key" || saved.Debrids[1].APIKey != "tb-key" {
+		t.Fatalf("api keys lost: %+v", saved.Debrids)
+	}
+	if len(saved.Arrs) != 1 || saved.Arrs[0].Token != "tok" {
+		t.Fatalf("partial POST wiped arrs: %+v", saved.Arrs)
+	}
+	if saved.DownloadFolder != "/downloads" {
+		t.Fatalf("partial POST wiped download_folder: %q", saved.DownloadFolder)
+	}
+}
+
+// TestHandleUpdateConfigExplicitEmptyStillClears: an explicitly posted empty
+// section is a real instruction and must clear, exactly as before the merge
+// fix.
+func TestHandleUpdateConfigExplicitEmptyStillClears(t *testing.T) {
+	s, cfgFile := setupConfigAPITest(t)
+
+	rec := postConfigUpdate(t, s, `{"debrids":[]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	saved := readSavedConfig(t, cfgFile)
+	if len(saved.Debrids) != 0 {
+		t.Fatalf("explicit empty debrids did not clear: %+v", saved.Debrids)
+	}
+	if len(saved.Arrs) != 1 {
+		t.Fatalf("omitted arrs must survive an explicit debrids clear: %+v", saved.Arrs)
+	}
+}
+
+// TestHandleUpdateConfigFullPostOverwrites: a full-config POST (every key the
+// web UI sends) keeps the pre-fix behavior — posted values win wholesale.
+func TestHandleUpdateConfigFullPostOverwrites(t *testing.T) {
+	s, cfgFile := setupConfigAPITest(t)
+
+	body := `{
+		"log_level": "trace",
+		"url_base": "/",
+		"bind_address": "127.0.0.1",
+		"app_url": "",
+		"port": "9999",
+		"allowed_file_types": ["mkv"],
+		"min_file_size": "",
+		"max_file_size": "",
+		"remove_stalled_after": "10m",
+		"nzb_user_agent": "",
+		"download_folder": "/new-downloads",
+		"refresh_interval": "30s",
+		"default_download_action": "symlink",
+		"max_active_downloads": 7,
+		"skip_pre_cache": false,
+		"always_rm_tracker_urls": false,
+		"folder_naming": "",
+		"disable_webdav": false,
+		"refresh_dirs": "",
+		"custom_folders": {},
+		"debrids": [{"name": "new", "provider": "realdebrid", "api_key": "new-key"}],
+		"arrs": [],
+		"queue_cleanup": {"rules": []},
+		"mount": {"type": "none", "mount_path": "/mnt"},
+		"usenet": {"providers": []},
+		"notifications": {"enabled": false},
+		"repair": {"enabled": false}
+	}`
+	rec := postConfigUpdate(t, s, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	saved := readSavedConfig(t, cfgFile)
+	if len(saved.Debrids) != 1 || saved.Debrids[0].APIKey != "new-key" {
+		t.Fatalf("full POST did not replace debrids wholesale: %+v", saved.Debrids)
+	}
+	if len(saved.Arrs) != 0 {
+		t.Fatalf("full POST with empty arrs did not clear them: %+v", saved.Arrs)
+	}
+	if saved.DownloadFolder != "/new-downloads" || saved.LogLevel != "trace" {
+		t.Fatalf("full POST fields not applied: folder=%q level=%q", saved.DownloadFolder, saved.LogLevel)
+	}
+}


### PR DESCRIPTION
**What breaks:** a `POST /api/config` body that omits a top-level section deletes that section from disk. Posting only `{"log_level":"debug"}` wipes `debrids` — configured providers and their api keys included — along with every other key the caller didn't mention.

**Why:** `handleUpdateConfig` in `pkg/server/api.go` decodes the body into a zero `config.Config`, so any absent top-level key ends up as its zero value, and the subsequent `newConfig.Save()` writes that zero value out.

**The fix:** merge on missing. `Config.PreserveMissingSections` copies every top-level section whose JSON key is absent from the posted body out of the live config before validation and save. Presence still wins wholesale, so an explicitly posted empty value (`"debrids": []`) clears exactly as before, and full-config POSTs (the web UI path) decode identically with and without the merge — there's a test asserting that.

**Evidence:** running in production on a ~47,000-entry library. Tests cover partial / explicit-empty / full POSTs at both the merge layer and the HTTP handler (asserting on-disk state); the partial-POST tests fail on `beta` without the change.

Split out of a second config-API fix (explicit `download_uncached: false` not persisting) so each is reviewable on its own; the two are independent.
