### PR TITLE
fix(server): require auth on the Tautulli webhook, and stop targetless payloads triggering a full sweep

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -151,8 +151,10 @@ func New(mgr *manager.Manager) *Server {
 			})
 		})
 
-		//webhooks
-		r.Post("/webhooks/tautulli", s.handleTautulli)
+		// Webhooks. Mounted behind authentication: these endpoints launch
+		// repair work, which can delete files, so they must not be reachable
+		// without credentials.
+		r.Mount("/webhooks", s.webhookRoutes())
 	})
 	s.router = r
 	return s

--- a/pkg/server/webhook.go
+++ b/pkg/server/webhook.go
@@ -2,18 +2,96 @@ package server
 
 import (
 	"cmp"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
 	json "github.com/bytedance/sonic"
-	"github.com/sirrobot01/decypharr/pkg/manager"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sirrobot01/decypharr/internal/config"
 )
 
-// handleTautulli handles webhooks from Tautulli. When the payload includes a
-// tvdb/tmdb id (or a generic media_id), the repair system runs a targeted
+// webhookRoutes returns the webhook router, mounted at /webhooks.
+//
+// Every route here is authenticated. These endpoints launch repair work, which
+// can delete files, so an unauthenticated caller must never reach them. The
+// Tautulli route was previously registered on the parent router, outside the
+// auth group, and required no credentials at all.
+func (s *Server) webhookRoutes() http.Handler {
+	r := chi.NewRouter()
+	r.Use(s.webhookAuthMiddleware)
+	r.Post("/tautulli", s.handleTautulli)
+	return r
+}
+
+// webhookAuthMiddleware rejects unauthenticated webhook calls with a JSON 401.
+func (s *Server) webhookAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.webhookAuthorized(r) {
+			s.sendJSONError(w,
+				"Authentication required. Provide the API token via the Authorization header "+
+					"(Bearer <token>), the X-API-Token header, or the ?token= query parameter.",
+				http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// webhookAuthorized reports whether a webhook request carries valid
+// credentials. The credential is the server's existing API token; no new auth
+// scheme is introduced.
+//
+// Besides the standard `Authorization: Bearer|Token <token>` header, the same
+// token is accepted from an `X-API-Token` header or a `?token=` / `?apikey=`
+// query parameter. Notification agents vary in what they can attach to an
+// outgoing request, and without a mechanism they can actually use, requiring
+// auth here would simply break every existing sender.
+//
+// use_auth == false preserves the existing global behaviour: the whole server
+// is intentionally open in that mode, and this endpoint is not special-cased
+// around it.
+func (s *Server) webhookAuthorized(r *http.Request) bool {
+	cfg := config.Get()
+	if !cfg.UseAuth {
+		return true
+	}
+	// GetAuth also lazily loads auth.json, so it must run before NeedsAuth.
+	auth := cfg.GetAuth()
+	if cfg.NeedsAuth() {
+		// Auth is enabled but no credentials exist yet: fail closed.
+		return false
+	}
+	if s.isValidAPIToken(r) {
+		return true
+	}
+	if auth == nil || auth.APIToken == "" {
+		return false
+	}
+	supplied := cmp.Or(
+		strings.TrimSpace(r.Header.Get("X-API-Token")),
+		strings.TrimSpace(r.URL.Query().Get("token")),
+		strings.TrimSpace(r.URL.Query().Get("apikey")),
+	)
+	if supplied == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(supplied), []byte(auth.APIToken)) == 1
+}
+
+// handleTautulli handles webhooks from Tautulli. The payload must carry a
+// tvdb/tmdb id (or a generic media_id): the repair system then runs a targeted
 // recheck against that specific media — the v2 equivalent of v1's
-// "media-id-scoped repair job". When no media id is supplied the webhook
-// falls back to a full manual sweep.
+// "media-id-scoped repair job".
+//
+// A payload with no media id is rejected with 400. It previously fell through
+// to svc.RunNow(...), i.e. a full library sweep using the operator's configured
+// repair settings, so a single untargeted notification could mass-delete.
+// Nothing about a Tautulli notification implies "sweep the entire library", so
+// the untargeted case is an explicit client error — and it is checked before
+// the repair service is looked up, so no path remains from an untargeted
+// payload to a sweep.
 func (s *Server) handleTautulli(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -38,20 +116,16 @@ func (s *Server) handleTautulli(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	svc := s.manager.Repair()
-	if svc == nil {
-		http.Error(w, "Repair service not available", http.StatusServiceUnavailable)
+	mediaID := strings.TrimSpace(cmp.Or(payload.MediaID, payload.TmdbID, payload.TvdbID))
+	if mediaID == "" {
+		// No targeting. Never fall back to a full sweep from a webhook.
+		http.Error(w, "media_id (or tmdb_id / tvdb_id) is required", http.StatusBadRequest)
 		return
 	}
 
-	mediaID := strings.TrimSpace(cmp.Or(payload.MediaID, payload.TmdbID, payload.TvdbID))
-	if mediaID == "" {
-		// No targeting → fall back to a full sweep.
-		if _, err := svc.RunNow(manager.RepairRunOptions{}); err != nil {
-			http.Error(w, err.Error(), http.StatusConflict)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+	svc := s.manager.Repair()
+	if svc == nil {
+		http.Error(w, "Repair service not available", http.StatusServiceUnavailable)
 		return
 	}
 

--- a/pkg/server/webhook_test.go
+++ b/pkg/server/webhook_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/logger"
+)
+
+const testAPIToken = "test-api-token"
+
+// newWebhookTestServer builds the smallest Server able to serve the webhook
+// router, with auth enabled and a known API token.
+//
+// manager is deliberately left nil. Both behaviours under test must be decided
+// before the repair service is ever looked up, so a nil manager is not a
+// limitation of the test — it is the assertion. Any path that reaches
+// s.manager.Repair() is by definition a path that reached repair work.
+func newWebhookTestServer(t *testing.T) *Server {
+	t.Helper()
+	config.Reset()
+	config.SetConfigPath(t.TempDir())
+	t.Cleanup(config.Reset)
+
+	cfg := config.Get()
+	cfg.UseAuth = true
+	cfg.Auth = &config.Auth{
+		Username: "user",
+		Password: "pass",
+		APIToken: testAPIToken,
+	}
+
+	return &Server{logger: logger.New("webhook-test")}
+}
+
+func postWebhook(t *testing.T, s *Server, target, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	recorder := httptest.NewRecorder()
+	s.webhookRoutes().ServeHTTP(recorder, req)
+	return recorder
+}
+
+// A targetless payload — valid JSON, correct topic, no media id. This is the
+// shape that previously fell through to a full repair sweep.
+const targetlessPayload = `{"topic":"tautulli","fix":true}`
+
+// TestTautulliWebhookRequiresAuth pins that the webhook is not reachable
+// without credentials. It was registered on the parent router, outside the auth
+// group, so any unauthenticated caller could invoke it.
+func TestTautulliWebhookRequiresAuth(t *testing.T) {
+	cases := []struct {
+		name    string
+		target  string
+		headers map[string]string
+	}{
+		{"no credentials at all", "/tautulli", nil},
+		{"wrong bearer token", "/tautulli", map[string]string{"Authorization": "Bearer not-the-token"}},
+		{"wrong X-API-Token", "/tautulli", map[string]string{"X-API-Token": "not-the-token"}},
+		{"wrong token query parameter", "/tautulli?token=not-the-token", nil},
+		{"empty token query parameter", "/tautulli?token=", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newWebhookTestServer(t)
+			recorder := postWebhook(t, s, tc.target, targetlessPayload, tc.headers)
+			if recorder.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401; body=%q", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+// TestTautulliWebhookAcceptsValidCredentials pins that the accepted credential
+// forms still work. Reaching 400 (the targetless rejection below) proves the
+// request passed authentication rather than being turned away at the door.
+func TestTautulliWebhookAcceptsValidCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		target  string
+		headers map[string]string
+	}{
+		{"bearer header", "/tautulli", map[string]string{"Authorization": "Bearer " + testAPIToken}},
+		{"token header", "/tautulli", map[string]string{"Authorization": "Token " + testAPIToken}},
+		{"X-API-Token header", "/tautulli", map[string]string{"X-API-Token": testAPIToken}},
+		{"token query parameter", "/tautulli?token=" + testAPIToken, nil},
+		{"apikey query parameter", "/tautulli?apikey=" + testAPIToken, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newWebhookTestServer(t)
+			recorder := postWebhook(t, s, tc.target, targetlessPayload, tc.headers)
+			if recorder.Code == http.StatusUnauthorized {
+				t.Fatalf("valid credentials rejected with 401; body=%q", recorder.Body.String())
+			}
+		})
+	}
+}
+
+// TestTautulliWebhookRejectsTargetlessPayload pins that a payload carrying no
+// media id is a client error, not an instruction to sweep the whole library.
+//
+// It previously fell through to svc.RunNow(...) — a full sweep using the
+// operator's configured repair settings, which can delete. Nothing about a
+// Tautulli notification implies "sweep everything".
+func TestTautulliWebhookRejectsTargetlessPayload(t *testing.T) {
+	for _, body := range []string{
+		`{"topic":"tautulli","fix":true}`,
+		`{"topic":"tautulli","fix":false}`,
+		`{"topic":"tautulli","arr":"radarr","fix":true}`,
+		`{"topic":"tautulli","media_id":"   ","fix":true}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			s := newWebhookTestServer(t)
+			recorder := postWebhook(t, s, "/tautulli", body,
+				map[string]string{"Authorization": "Bearer " + testAPIToken})
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%q", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+// TestTautulliWebhookAuthDisabledStaysOpen pins that use_auth=false is
+// unchanged. The whole server is intentionally open in that mode and this
+// endpoint is not special-cased around it.
+func TestTautulliWebhookAuthDisabledStaysOpen(t *testing.T) {
+	config.Reset()
+	config.SetConfigPath(t.TempDir())
+	t.Cleanup(config.Reset)
+	config.Get().UseAuth = false
+
+	s := &Server{logger: logger.New("webhook-test")}
+	recorder := postWebhook(t, s, "/tautulli", targetlessPayload, nil)
+	if recorder.Code == http.StatusUnauthorized {
+		t.Fatal("use_auth=false must not require webhook credentials")
+	}
+}


### PR DESCRIPTION
**What breaks:** `POST /webhooks/tautulli` requires no credentials, and an untargeted payload sent to it starts a full repair sweep. With destructive repair actions enabled, an unauthenticated request can mass-delete.

**Why:** the route is registered on the parent router in `pkg/server/server.go`, outside the authenticated group — every other mutating endpoint sits inside it. Separately, `handleTautulli` treats "no media id" as "sweep everything": it falls through to `svc.RunNow(manager.RepairRunOptions{})`, which uses the operator's configured repair settings.

Either alone is awkward; together they mean an anonymous `curl` with a two-field JSON body can delete library content.

**The fix:** two changes, both small.

1. Mount the webhooks behind a router that requires the existing API token. No new auth scheme is introduced. Alongside the standard `Authorization: Bearer|Token <token>` header, an `X-API-Token` header and a `?token=` / `?apikey=` query parameter are accepted — notification agents differ in what they can attach to an outgoing request, and requiring a form some senders cannot produce would just break existing setups. `use_auth=false` is deliberately unchanged: the whole server is open in that mode and this endpoint is not special-cased around it.
2. Reject a payload with no media id as `400` instead of sweeping. Nothing about a Tautulli notification implies "sweep the entire library". The check now runs *before* the repair service is looked up, so there is no remaining path from an untargeted payload to a sweep.

**Evidence:** running in production on a ~47,000-entry library. Tests cover unauthenticated and wrong-credential rejection, each accepted credential form, the targetless rejection, and the `use_auth=false` passthrough.

The tests construct the server with a **nil manager on purpose**: both behaviours must be decided before the repair service is ever reached, so reaching it is itself the failure. Run against the previous behaviour, the auth test doesn't merely fail — it panics inside `s.manager.Repair()`, which is the defect rendered as a stack trace: an unauthenticated request arriving at the repair service.