### PR TITLE
fix(qbit): treat qBittorrent's "all" sentinel as unfiltered instead of as a literal value

### DIFF
--- a/pkg/manager/queue.go
+++ b/pkg/manager/queue.go
@@ -170,14 +170,18 @@ func (q *Queue) Update(torrent *storage.Entry) error {
 
 func (q *Queue) ListFilterFunc(category string, protocol config.Protocol, state storage.TorrentState, hashes []string) func(*storage.Entry) bool {
 	hashSet := make(map[string]struct{}, len(hashes))
-	if len(hashes) > 0 {
+	// qBittorrent uses "all" as a sentinel for "every torrent", so `hashes=all`
+	// must not be matched as a literal infohash -- doing so filters for a
+	// torrent whose hash is the string "all" and returns nothing.
+	allHashes := len(hashes) == 1 && strings.EqualFold(strings.TrimSpace(hashes[0]), "all")
+	if len(hashes) > 0 && !allHashes {
 		for _, h := range hashes {
 			hashSet[strings.ToLower(h)] = struct{}{}
 		}
 	}
 
 	var filterFunc func(*storage.Entry) bool
-	if category != "" || len(hashes) != 0 || state != "" || protocol != config.ProtocolAll {
+	if category != "" || (len(hashes) != 0 && !allHashes) || state != "" || protocol != config.ProtocolAll {
 		filterFunc = func(t *storage.Entry) bool {
 			if category != "" && t.Category != category {
 				return false

--- a/pkg/manager/queue_all_sentinel_test.go
+++ b/pkg/manager/queue_all_sentinel_test.go
@@ -1,0 +1,69 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/pkg/storage"
+)
+
+// qBittorrent uses "all" as a sentinel meaning "no filtering" for both the
+// `filter` and `hashes` parameters. Treated as a literal it matches nothing:
+// no entry has the state "all", and no torrent has the infohash "all". A client
+// that sends either explicitly then receives an empty list.
+func TestListFilterFuncTreatsHashesAllAsUnfiltered(t *testing.T) {
+	q := &Queue{}
+
+	entries := []*storage.Entry{
+		{InfoHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Category: "radarr", Protocol: config.ProtocolTorrent},
+		{InfoHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Category: "sonarr", Protocol: config.ProtocolTorrent},
+	}
+
+	count := func(filter func(*storage.Entry) bool) int {
+		if filter == nil {
+			return len(entries)
+		}
+		n := 0
+		for _, e := range entries {
+			if filter(e) {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("hashes=all matches everything", func(t *testing.T) {
+		got := count(q.ListFilterFunc("", config.ProtocolAll, "", []string{"all"}))
+		if got != len(entries) {
+			t.Fatalf("hashes=all matched %d of %d entries; the sentinel was treated as a literal infohash", got, len(entries))
+		}
+	})
+
+	t.Run("hashes=ALL is case-insensitive", func(t *testing.T) {
+		if got := count(q.ListFilterFunc("", config.ProtocolAll, "", []string{"ALL"})); got != len(entries) {
+			t.Fatalf("hashes=ALL matched %d of %d entries", got, len(entries))
+		}
+	})
+
+	t.Run("a real infohash still filters", func(t *testing.T) {
+		got := count(q.ListFilterFunc("", config.ProtocolAll, "", []string{entries[0].InfoHash}))
+		if got != 1 {
+			t.Fatalf("explicit infohash matched %d entries, want 1", got)
+		}
+	})
+
+	t.Run("hashes=all still honours other filters", func(t *testing.T) {
+		got := count(q.ListFilterFunc("radarr", config.ProtocolAll, "", []string{"all"}))
+		if got != 1 {
+			t.Fatalf("category=radarr with hashes=all matched %d entries, want 1", got)
+		}
+	})
+
+	t.Run("multiple hashes including all are treated literally", func(t *testing.T) {
+		// Only a lone "all" is the sentinel; a list is a genuine selection.
+		got := count(q.ListFilterFunc("", config.ProtocolAll, "", []string{"all", entries[0].InfoHash}))
+		if got != 1 {
+			t.Fatalf("mixed hash list matched %d entries, want 1", got)
+		}
+	})
+}

--- a/pkg/server/qbit/filter_all_test.go
+++ b/pkg/server/qbit/filter_all_test.go
@@ -1,0 +1,47 @@
+package qbit
+
+import (
+	"strings"
+	"testing"
+)
+
+// qBittorrent's `filter` parameter defaults to "all", meaning unfiltered. It is
+// not a storage.TorrentState, so forwarding it as one matched no entry and
+// returned an empty list to any client that sent it explicitly.
+//
+// This exercises the function handleTorrentsInfo actually calls, not a copy of
+// its logic.
+func TestNormalizeStateFilter(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"all is the default sentinel", "all", ""},
+		{"sentinel is case-insensitive", "ALL", ""},
+		{"sentinel tolerates surrounding space", "  all  ", ""},
+		{"absent filter is unfiltered", "", ""},
+		{"whitespace-only is unfiltered", "   ", ""},
+		{"a real state is preserved", "downloading", "downloading"},
+		{"an unrecognised value is preserved verbatim", "seeding", "seeding"},
+		{"a real state is trimmed", "  downloading  ", "downloading"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeStateFilter(tc.raw); got != tc.want {
+				t.Fatalf("normalizeStateFilter(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// strings.Trim with an empty cutset trims nothing — including the whitespace it
+// looks like it should remove. Pinned so the replacement is not quietly
+// reverted to it.
+func TestTrimWithEmptyCutsetIsANoOp(t *testing.T) {
+	const padded = "  all  "
+	if strings.Trim(padded, "") != padded {
+		t.Fatal("strings.Trim with an empty cutset unexpectedly trimmed something")
+	}
+}

--- a/pkg/server/qbit/http.go
+++ b/pkg/server/qbit/http.go
@@ -66,11 +66,26 @@ func (q *QBit) handleShutdown(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// normalizeStateFilter maps qBittorrent's `filter` query parameter onto a
+// storage.TorrentState.
+//
+// qBittorrent's filter defaults to "all", meaning unfiltered. "all" is not a
+// TorrentState, so forwarding it as one matched no entry and returned an empty
+// list to any client that sent it explicitly. The previous
+// strings.Trim(value, "") was also a no-op — an empty cutset trims nothing.
+func normalizeStateFilter(raw string) string {
+	state := strings.TrimSpace(raw)
+	if strings.EqualFold(state, "all") {
+		return ""
+	}
+	return state
+}
+
 func (q *QBit) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
 	//log all url params
 	ctx := r.Context()
 	category := getCategory(ctx)
-	state := strings.Trim(r.URL.Query().Get("filter"), "")
+	state := normalizeStateFilter(r.URL.Query().Get("filter"))
 	hashes := getHashes(ctx)
 
 	// Convert hashes to filter function


### PR DESCRIPTION
**What breaks:** `GET /api/v2/torrents/info?filter=all` returns `[]`, even when torrents exist. Same for `hashes=all`.

**Why:** qBittorrent uses `all` to mean *no filtering* for both parameters, and both are matched literally.

- `handleTorrentsInfo` forwards `filter` straight through as a `storage.TorrentState`, so `ListFilterFunc` evaluates `t.State != "all"` — true for every entry, so nothing matches. (The neighbouring `strings.Trim(value, "")` is also a no-op: an empty cutset trims nothing, so a padded value isn't trimmed either.)
- `ListFilterFunc` adds every supplied hash to the match set, so `hashes=all` filters for a torrent whose infohash is the literal string `all`.

`all` is the qBittorrent default, so any client that sends it explicitly sees an empty queue rather than an error — which reads as "nothing is downloading" rather than as a bug.

**The fix:** treat the sentinel as unfiltered in both places.

Normalisation moved into `normalizeStateFilter`, which the handler calls, so the behaviour is tested through the production path rather than through a copy of the logic in a test file. For `hashes`, only a *lone* `all` is the sentinel — a list containing it stays a literal selection, since a multi-hash request is a genuine choice of torrents. Unrecognised filter values are still passed through verbatim rather than guessed at, and every other filter still applies alongside the sentinel.

**Evidence:** running in production on a ~47,000-entry library, where this was found while diagnosing an unrelated issue: a same-instant census showed `/api/torrents` returning 117 rows while `?filter=all` returned 0.

Both tests fail on the current behaviour at the described defect, and the "a real state" / "a real infohash" cases pass with and without the change, so neither can pass by over-correcting.