### PR TITLE
stream: honour StreamError.Retryable and retry transient upstream statuses

### DIFF
--- a/pkg/manager/stream.go
+++ b/pkg/manager/stream.go
@@ -101,6 +101,17 @@ func (e StreamError) Error() string {
 	return e.Err.Error()
 }
 
+// IsRetryable satisfies the selfRetryable interface that
+// customerror.IsRetriableError probes for, so the Retryable field above
+// actually reaches the retry loops in pkg/mount/dfs/vfs/downloaders.go
+// (DownloadWithRetry, downloadChunkWithRetry).
+//
+// Without this method nothing ever reads StreamError.Retryable: the field is
+// set in three places in this file but has no effect on any decision.
+func (e StreamError) IsRetryable() bool {
+	return e.Retryable
+}
+
 // StreamMetadata describes the headers/status for a streaming response before data flows.
 type StreamMetadata struct {
 	Header        http.Header
@@ -274,6 +285,26 @@ func (m *Manager) streamHTTP(ctx context.Context, torrent *storage.Entry, filena
 	}
 
 	resp.Body.Close()
+
+	// Transient upstream statuses must not abort the stream. Debrid providers
+	// emit 429 routinely under load, and 5xx sporadically; treating them as
+	// unrecoverable kills playback for the whole session, because ffmpeg sees
+	// an I/O error and the player keeps requesting segments that never arrive.
+	// Returning a retryable StreamError lets the existing retry loops back off
+	// and try again instead.
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return StreamError{
+			Err:       fmt.Errorf("transient HTTP status: %d", resp.StatusCode),
+			Retryable: true,
+			LinkError: false,
+		}
+	}
+
 	return retry.Unrecoverable(StreamError{
 		Err:       fmt.Errorf("unexpected HTTP status: %d", resp.StatusCode),
 		Retryable: false,

--- a/pkg/manager/stream_retry_test.go
+++ b/pkg/manager/stream_retry_test.go
@@ -1,0 +1,32 @@
+package manager
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/customerror"
+)
+
+// StreamError sets a Retryable field in three places in stream.go, but until it
+// implements IsRetryable() nothing reads it: customerror.IsRetriableError probes
+// for that exact method (see the selfRetryable interface in
+// internal/customerror/retry.go). Without it every stream error is treated as
+// fatal by DownloadWithRetry / downloadChunkWithRetry, so a single transient
+// upstream status ends playback for the session.
+func TestStreamErrorRetryabilityIsHonoured(t *testing.T) {
+	transient := StreamError{
+		Err:       errors.New("transient HTTP status: 502"),
+		Retryable: true,
+	}
+	if !customerror.IsRetriableError(transient) {
+		t.Error("a retryable StreamError is not reported as retriable: the retry loops will give up and playback dies")
+	}
+
+	fatal := StreamError{
+		Err:       errors.New("unexpected HTTP status: 416"),
+		Retryable: false,
+	}
+	if customerror.IsRetriableError(fatal) {
+		t.Error("a non-retryable StreamError is reported as retriable: the retry loops would spin on a permanent failure")
+	}
+}


### PR DESCRIPTION
## 📌 Description

- `StreamError` has a `Retryable` field that nothing ever reads, so transient upstream statuses end playback instead of being retried.


Reported in #345.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

- Add `StreamError.IsRetryable()`. `customerror.IsRetriableError` probes for a `selfRetryable` interface (`IsRetryable() bool`, see `internal/customerror/retry.go`). `StreamError` did not implement it, so the `Retryable` field had no effect on any decision: it is set in three places in `stream.go` and read in none. One of those call sites builds `StreamError{..., Retryable: true}` and immediately wraps it in `retry.Unrecoverable(...)`, which is self-contradictory.
- In `streamHTTP`, stop classifying transient upstream statuses as unrecoverable. `429`, `500`, `502`, `503` and `504` now return a retryable `StreamError` so the existing retry loops in `pkg/mount/dfs/vfs/downloaders.go` (`DownloadWithRetry`, `downloadChunkWithRetry`) can back off and try again. Every other unexpected status keeps the previous `retry.Unrecoverable` behaviour.
- Add `pkg/manager/stream_retry_test.go` asserting both directions of the decision.

---

## Testing

- [x] Tested locally

Steps:

1. `go test ./pkg/manager/ -run TestStreamErrorRetryabilityIsHonoured -v` passes with the change, and fails without it (the retryable case is reported as non-retriable).
2. Ran the patched build against a TorBox account for several days under a heavy import load, which produces 429s routinely. Before: a single 429 or 502 mid-stream ended the session: ffmpeg exits with an I/O error and the player keeps requesting segments that never arrive, so playback is dead until the client starts a new session. After: the log shows `stream error, retrying ... attempt=1` and playback continues.
3. Confirmed no regression on genuinely fatal statuses: a `416` still terminates the stream immediately.

---

## Risks / Notes

- Adding `IsRetryable()` makes the field meaningful, so it also changes behaviour at one pre-existing call site: `StreamError{Err: ..., Retryable: true}` returned after "connection retry exhausted" is now seen as retriable by the outer loop. That looks intended (the inner loop exhausting its own attempts does not mean the outer layer should give up), but it is a behaviour change worth a second opinion, and I am happy to gate that one differently if you prefer.
- Retries are bounded by the existing loops, so this cannot spin indefinitely.
- No config, API or on-disk format changes.

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct