### PR TITLE
link: transient and unknown provider codes must not be cached as permanent

### DIFF
--- a/pkg/manager/link/errors.go
+++ b/pkg/manager/link/errors.go
@@ -143,12 +143,31 @@ func ErrorCodeToLinkError(code string) *Error {
 		return NewPermanentError(ErrUnauthorized, code)
 	case "404":
 		return NewPermanentError(Err404, code)
+	// Transient provider codes have to be Refetchable, not Retryable.
+	//
+	// On the link-validation path only ShouldDisableAccount() and
+	// ShouldRefetch() are consulted. A CategoryRetryable error is acted on by
+	// neither, so it falls through and the failure is memoised against the
+	// download URL. For providers whose download URL is deterministic the cache
+	// key never rotates, which makes a rate limit as permanent as a hard
+	// failure: the file stays unreadable for the rest of the process lifetime
+	// and only a restart clears it.
+	//
+	// Refetchable is the category that escapes the cache: it drops the stored
+	// entry and returns a fresh link without re-validating, so it cannot loop.
 	case "429":
-		return NewRetryableError(Err429, code)
+		return NewRefetchableError(Err429, code)
 	case "503":
-		return NewRetryableError(Err503, code)
+		return NewRefetchableError(Err503, code)
+	case "500", "502", "504":
+		return NewRefetchableError(fmt.Errorf("HTTP %s from provider", code), code)
 	default:
-		return NewPermanentError(fmt.Errorf("unknown error code: %s", code), code)
+		// An unrecognised code is not evidence of permanent failure. Treating it
+		// as permanent means one transient 400 poisons the file until restart,
+		// which is what users see as "playback works, then stops until I
+		// restart the container". Allow a refetch instead, which also clears any
+		// poisoned cache entry.
+		return NewRefetchableError(fmt.Errorf("unknown error code: %s", code), code)
 	}
 }
 

--- a/pkg/manager/link/errors_category_test.go
+++ b/pkg/manager/link/errors_category_test.go
@@ -1,0 +1,34 @@
+package link
+
+import "testing"
+
+// Transient provider codes must land in the Refetchable category: it is the only
+// one the validation path acts on, so it is the only one that drops the memoised
+// failure and asks for a fresh link. Anything else leaves the entry cached and
+// the file unreadable until the process restarts.
+//
+// The second half guards against over-correcting: genuinely permanent codes must
+// stay permanent, otherwise the caller would refetch forever on a dead file.
+func TestTransientCodesAreRefetchable(t *testing.T) {
+	transient := []string{"400", "429", "500", "502", "503", "504", "some_unrecognised_code"}
+	for _, code := range transient {
+		e := ErrorCodeToLinkError(code)
+		if e.IsPermanent() {
+			t.Errorf("code %q classified as permanent: the file would stay unreadable until restart", code)
+		}
+		if !e.ShouldRefetch() {
+			t.Errorf("code %q: ShouldRefetch() is false, so the memoised failure is never cleared", code)
+		}
+	}
+
+	permanent := []string{"401", "unauthorized", "404", "link_not_found", "file_not_available"}
+	for _, code := range permanent {
+		e := ErrorCodeToLinkError(code)
+		if !e.IsPermanent() {
+			t.Errorf("code %q should remain permanent", code)
+		}
+		if e.ShouldRefetch() {
+			t.Errorf("code %q should not trigger a refetch", code)
+		}
+	}
+}


### PR DESCRIPTION
## 📌 Description

- One transient provider error makes a file unreadable for the rest of the process lifetime, because the failure is cached and only a restart clears it. This is the mechanism behind "playback works, then stops until I restart the container".


Reported in #179.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

In `ErrorCodeToLinkError` (`pkg/manager/link/errors.go`):

- `429` and `503`: `CategoryRetryable` → `CategoryRefetchable`. On the link-validation path only `ShouldDisableAccount()` and `ShouldRefetch()` are consulted, and `CategoryRetryable` is acted on by neither, so the error falls through and the failure is memoised against the download URL. When a provider derives that URL deterministically the cache key never rotates, which makes a rate limit exactly as permanent as a hard failure.
- Added `500`, `502`, `504` as `Refetchable` for the same reason.
- `default`: `CategoryPermanent` → `CategoryRefetchable`. An unrecognised code is not evidence of permanent failure, and `CategoryPermanent` means neither retry nor refetch, so a single transient `400` poisons the file until the process restarts.
- Genuinely permanent codes are **unchanged**: `401`/`unauthorized`, `404`, `link_not_found`, `file_not_available`, and the account/quota codes.
- Added `pkg/manager/link/errors_category_test.go` asserting both directions.

`Refetchable` is the right category here because it is the only one that drops the memoised entry and returns a fresh link, and it does so *without* re-validating, so it cannot loop.

---

## Testing

- [x] Tested locally

Steps:

1. `go test ./pkg/manager/link/ -run TestTransientCodesAreRefetchable -v` passes with the change. Without it, `400` and unknown codes are reported permanent and `429`/`503` do not refetch.
2. Ran the patched build for several days on a ~4000-file TorBox library. Before the change, a single transient `502` during validation left files unreadable while the very same HEAD request returned `200` when retried by hand. I reproduced that three times. After the change, those files recover on their own without restarting the container.
3. Verified the permanent codes still terminate immediately: a real `404` is not retried in a loop.

---

## Risks / Notes

- Broadens what gets a second chance, so a genuinely dead link now costs one extra refetch before failing. That refetch does not re-validate, so there is no loop and no added latency on the happy path.
- Behaviour for permanent codes is unchanged, which the test pins down explicitly to guard against over-correcting.
- No config, API or on-disk format changes.
- Independent of the streaming PR (different package, different code path); order does not matter, though the streaming one is the smaller review.

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct