### PR TITLE
torbox: check the cache before createtorrent when download_uncached is false

### DIFF
--- a/pkg/debrid/providers/torbox/cached_check_test.go
+++ b/pkg/debrid/providers/torbox/cached_check_test.go
@@ -1,0 +1,172 @@
+package torbox
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/request"
+	"github.com/sirrobot01/decypharr/internal/utils"
+	"github.com/sirrobot01/decypharr/pkg/debrid/types"
+)
+
+// config.Get() is reached through SubmitMagnet and calls os.Exit(1) when it
+// cannot write its file, so point it at a scratch directory before any test runs.
+// os.Exit skips deferred calls, hence the explicit cleanup around m.Run().
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "decypharr-torbox-test")
+	if err != nil {
+		panic(err)
+	}
+	config.SetConfigPath(dir)
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+const testHash = "0123456789abcdef0123456789abcdef01234567"
+
+func newTestTorbox(t *testing.T, h http.HandlerFunc) *Torbox {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return &Torbox{
+		Host:   srv.URL,
+		client: request.New(request.WithMaxRetries(0)),
+	}
+}
+
+// A cache probe has three outcomes, and the third must stay distinguishable from
+// the second: "the probe failed" is not "not cached".
+func TestIsCachedSeparatesUnknownFromNegative(t *testing.T) {
+	cases := []struct {
+		name          string
+		handler       http.HandlerFunc
+		hash          string
+		cached, known bool
+	}{
+		{
+			name: "present in cache",
+			hash: testHash,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true,"data":{"` + testHash +
+					`":{"name":"x","size":123,"hash":"` + testHash + `"}}}`))
+			},
+			cached: true, known: true,
+		},
+		{
+			name: "answered, hash absent",
+			hash: testHash,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
+			},
+			cached: false, known: true,
+		},
+		{
+			name: "probe failed: must be unknown, not negative",
+			hash: testHash,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			cached: false, known: false,
+		},
+		{
+			name:    "empty hash is unknown, not negative",
+			hash:    "",
+			handler: func(w http.ResponseWriter, r *http.Request) { t.Fatal("must not be called") },
+			cached:  false, known: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tb := newTestTorbox(t, tc.handler)
+			cached, known := tb.isCached(tc.hash)
+			if cached != tc.cached || known != tc.known {
+				t.Fatalf("isCached() = (%v, %v), want (%v, %v)", cached, known, tc.cached, tc.known)
+			}
+		})
+	}
+}
+
+// The point of the check is to refuse cheaply *before* createtorrent, and to stay
+// out of the way whenever the answer is not conclusive.
+func TestSubmitMagnetSkipsCreateTorrentOnlyWhenKnownUncached(t *testing.T) {
+	cases := []struct {
+		name             string
+		checkcached      func(w http.ResponseWriter)
+		downloadUncached bool
+		wantCreateCalled bool
+		wantErr          bool
+	}{
+		{
+			name: "known uncached: refuse without calling createtorrent",
+			checkcached: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
+			},
+			wantCreateCalled: false, wantErr: true,
+		},
+		{
+			name: "probe failed: fall through to createtorrent as before",
+			checkcached: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantCreateCalled: true, wantErr: false,
+		},
+		{
+			name: "cached: proceed to createtorrent",
+			checkcached: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true,"data":{"` + testHash +
+					`":{"name":"x","size":123,"hash":"` + testHash + `"}}}`))
+			},
+			wantCreateCalled: true, wantErr: false,
+		},
+		{
+			name: "download_uncached: never probe, never refuse",
+			checkcached: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusTeapot) // must not be reached
+			},
+			downloadUncached: true,
+			wantCreateCalled: true, wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var createCalled bool
+			tb := newTestTorbox(t, func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/torrents/checkcached":
+					tc.checkcached(w)
+				case "/api/torrents/createtorrent":
+					createCalled = true
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"success":true,"data":{"torrent_id":1,"hash":"` +
+						testHash + `"}}`))
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			})
+
+			_, err := tb.SubmitMagnet(&types.Torrent{
+				InfoHash:         testHash,
+				Name:             "some.release",
+				DownloadUncached: tc.downloadUncached,
+				Magnet:           &utils.Magnet{Link: "magnet:?xt=urn:btih:" + testHash},
+			})
+
+			if createCalled != tc.wantCreateCalled {
+				t.Errorf("createtorrent called = %v, want %v", createCalled, tc.wantCreateCalled)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("SubmitMagnet() error = %v, want error = %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/debrid/providers/torbox/torbox.go
+++ b/pkg/debrid/providers/torbox/torbox.go
@@ -232,6 +232,34 @@ func (tb *Torbox) IsAvailable(hashes []string) map[string]bool {
 	return result
 }
 
+// isCached reports whether a single info hash is present in TorBox's cache.
+//
+// The second return value states whether the answer is trustworthy. A transport
+// error, a non-2xx reply or a malformed body yields (false, false), and callers
+// must not read that as "not cached": absence of information is not evidence of
+// absence. Acting on an unknown answer as though it were a negative one is how a
+// cache probe turns into a mass false-positive machine.
+//
+// IsAvailable cannot be reused for this: it skips failed batches with `continue`,
+// so a probe that failed and a hash that is genuinely absent both surface as a
+// missing map key. That distinction is the whole point here.
+func (tb *Torbox) isCached(hash string) (cached bool, known bool) {
+	if hash == "" {
+		return false, false
+	}
+	var res AvailableResponse
+	resp, err := tb.doGet("/api/torrents/checkcached", map[string]string{"hash": hash}, &res)
+	if err != nil || resp == nil || resp.StatusCode < 200 || resp.StatusCode >= 300 || res.Data == nil {
+		return false, false
+	}
+	for h, c := range *res.Data {
+		if strings.EqualFold(h, hash) && c.Size > 0 {
+			return true, true
+		}
+	}
+	return false, true
+}
+
 func (tb *Torbox) SubmitMagnet(torrent *types.Torrent) (*types.Torrent, error) {
 	var data AddMagnetResponse
 
@@ -240,6 +268,19 @@ func (tb *Torbox) SubmitMagnet(torrent *types.Torrent) (*types.Torrent, error) {
 	}
 	if !torrent.DownloadUncached {
 		formData["add_only_if_cached"] = "true"
+
+		// Ask the cache before calling createtorrent. When a release is not
+		// cached TorBox does not reply with a refusal, it does not reply at
+		// all: the request wrapper then burns ResponseHeaderTimeout (30s) per
+		// attempt and retries cfg.Retries times, so one uncached grab can cost
+		// around two minutes. The calling *arr times out well before that and
+		// records the failure against the INDEXER, which it eventually
+		// disables, for a release the indexer served perfectly well.
+		// Failing fast keeps the refusal cheap and keeps the blame off the
+		// indexer. An unknown answer falls through to the previous behaviour.
+		if cached, known := tb.isCached(torrent.InfoHash); known && !cached {
+			return nil, fmt.Errorf("torrent: %s not cached", torrent.Name)
+		}
 	}
 
 	resp, err := tb.doPostForm("/api/torrents/createtorrent", formData, &data)


### PR DESCRIPTION
## 📌 Description

- With `download_uncached=false`, adding an uncached release is not refused quickly: it hangs, retries, and costs up to two minutes before failing. The calling *arr times out first and blames the indexer.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

`SubmitMagnet` already sets `add_only_if_cached=true` when `download_uncached` is false, which is the correct protection. The problem is its cost, not its outcome. TorBox does not answer an uncached `createtorrent` with a refusal, it does not answer at all: `ResponseHeaderTimeout` is 30s (`internal/request/request.go`) and the wrapper retries `cfg.Retries` times, so one uncached grab can take about two minutes and surfaces as `http2: timeout awaiting response headers` followed by `giving up after 4 attempt(s)`. Sonarr and Radarr time out well before that, log `Couldn't add release ... to download queue`, and record the failure against the **indexer**, which they eventually disable. The indexer did nothing wrong.

- Add `Torbox.isCached(hash) (cached, known bool)`, a single-hash probe of `/api/torrents/checkcached`.
- Call it in `SubmitMagnet` before `createtorrent`, and only when `download_uncached` is false. A definite miss returns `torrent: %s not cached` immediately instead of waiting for the timeouts.
- Add `pkg/debrid/providers/torbox/cached_check_test.go` covering both the probe and the call site.

The second return value is the point of the design. A transport error, a non-2xx reply or a malformed body gives `(false, false)`, and the caller falls through to the previous behaviour instead of refusing. Treating "I could not find out" as "not cached" would turn a flaky probe into a machine for refusing perfectly good releases, so the check only ever acts on a definite answer.

`IsAvailable` could not be reused here: it skips failed batches with `continue`, so a probe that failed and a hash that is genuinely absent both come back as a missing map key. That is exactly the distinction this change depends on. I left `IsAvailable` untouched rather than change its signature.

---

## Testing

- [x] Tested locally

Steps:

1. `go test ./pkg/debrid/providers/torbox/ -v` passes. Reverting only the change to `torbox.go` makes `TestSubmitMagnetSkipsCreateTorrentOnlyWhenKnownUncached` fail with `createtorrent called = true, want false`, while the three cases that assert unchanged behaviour still pass.
2. `gofmt` and `go vet` are clean on the package.
3. Ran the patched build for a day on a TorBox account with roughly 5500 torrents. Refusals that previously took 90 to 120 seconds now take 0.2 to 0.7 seconds, measured over 25 minutes: 9 refusals out of 9 took the fast path, and `giving up after 4 attempt(s)` disappeared from the logs.
4. Checked the probe against a population of hashes known to be cached before submission: 60 out of 60 answered correctly, no false negatives.

Note on step 4: an earlier measurement of mine suggested a 35% false negative rate and was wrong. It queried hashes that were already present in the account, which is a different question from "is this in the cache". Worth stating in case someone repeats the check: compare `cached_at` against `created_at`, because a torrent that has been downloaded becomes cached afterwards.

---

## Risks / Notes

- One extra HTTP call per uncached submission. It replaces up to four calls that each wait 30s, so it is strictly cheaper on that path. Cached submissions pay one `checkcached` round trip, about 1s for a batch of 10 hashes in my measurements, against the `createtorrent` call they were already making.
- No behaviour change when `download_uncached` is true: the probe is not reached.
- No config, API or on-disk format changes.
- Independent of #368 and #369 (different package, different code path).

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct