### PR TITLE
fix(link): prevent unbounded requestdl API calls on persistent CDN 404

### DIFF
--- a/pkg/manager/link/errors.go
+++ b/pkg/manager/link/errors.go
@@ -142,7 +142,10 @@ func ErrorCodeToLinkError(code string) *Error {
 	case "401", "unauthorized":
 		return NewPermanentError(ErrUnauthorized, code)
 	case "404":
-		return NewPermanentError(Err404, code)
+		// CDN 404 during validation means the URL is not yet active or has expired,
+		// not that the file is permanently gone. Refetch so a fresh CDN URL is
+		// generated — the prior URL may have been fetched before the file was ready.
+		return NewRefetchableError(Err404, code)
 	case "429":
 		return NewRetryableError(Err429, code)
 	case "503":

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -19,6 +19,16 @@ import (
 
 const (
 	MaxReinsertionAttempt = 3
+
+	// Retry config for transient errors (429, 502, 503, 504) during link validation.
+	maxRetryableAttempts = 5
+	retryableBaseDelay   = 2 * time.Second
+	retryableMaxDelay    = 30 * time.Second
+
+	// After a 404 refetch, block further requestdl calls for this window.
+	// Prevents hammering the provider API when a file is persistently
+	// unavailable (still processing or genuinely gone from the debrid cache).
+	refetchCooldownDuration = 5 * time.Minute
 )
 
 var (
@@ -33,15 +43,16 @@ type EntrySaver func(entry *storage.Entry) error
 // Service handles download link fetching and validation.
 // It uses the account-level cache for storing links and only tracks validation state.
 type Service struct {
-	validated      *xsync.Map[string, error]
-	singleflight   singleflight.Group
-	clients        *xsync.Map[string, debrid.Client]
-	entryRefresher EntryRefresher
-	repairer       EntryRepairer
-	entrySaver     EntrySaver
-	httpClient     *http.Client
-	retries        int
-	logger         zerolog.Logger
+	validated        *xsync.Map[string, error]
+	refetchCooldowns *xsync.Map[string, time.Time]
+	singleflight     singleflight.Group
+	clients          *xsync.Map[string, debrid.Client]
+	entryRefresher   EntryRefresher
+	repairer         EntryRepairer
+	entrySaver       EntrySaver
+	httpClient       *http.Client
+	retries          int
+	logger           zerolog.Logger
 }
 
 // New creates a new LinkService
@@ -55,14 +66,15 @@ func New(
 	logger zerolog.Logger,
 ) *Service {
 	return &Service{
-		validated:      xsync.NewMap[string, error](),
-		clients:        clients,
-		entryRefresher: entryRefresher,
-		repairer:       entryReinsert,
-		entrySaver:     entrySaver,
-		httpClient:     httpClient,
-		retries:        retries,
-		logger:         logger,
+		validated:        xsync.NewMap[string, error](),
+		refetchCooldowns: xsync.NewMap[string, time.Time](),
+		clients:          clients,
+		entryRefresher:   entryRefresher,
+		repairer:         entryReinsert,
+		entrySaver:       entrySaver,
+		httpClient:       httpClient,
+		retries:          retries,
+		logger:           logger,
 	}
 }
 
@@ -112,7 +124,11 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 		// Previous validation failed - check if we should retry
 		if linkErr := GetLinkError(validationErr); linkErr != nil {
 			if linkErr.ShouldRefetch() {
-				// Invalidate and refetch
+				fileKey := entry.InfoHash + ":" + filename
+				if !s.refetchAllowed(fileKey) {
+					return emptyDownloadLink, validationErr
+				}
+				s.setRefetchCooldown(fileKey)
 				return s.invalidateAndRefetch(ctx, entry, link, attempt)
 			}
 		}
@@ -139,7 +155,11 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 					return s.fetchAndValidate(ctx, entry, filename, attempt)
 				}
 			} else if linkErr.ShouldRefetch() {
-				// Invalidate and refetch
+				fileKey := entry.InfoHash + ":" + filename
+				if !s.refetchAllowed(fileKey) {
+					return emptyDownloadLink, validationErr
+				}
+				s.setRefetchCooldown(fileKey)
 				return s.invalidateAndRefetch(ctx, entry, link, attempt)
 			}
 		}
@@ -149,9 +169,25 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 	s.validated.Store(link.DownloadLink, validationErr)
 
 	if validationErr == nil {
+		// File is accessible — clear any pending refetch cooldown so that
+		// future requests are not artificially delayed.
+		s.refetchCooldowns.Delete(entry.InfoHash + ":" + filename)
 		return link, nil
 	}
 	return emptyDownloadLink, validationErr
+}
+
+// refetchAllowed returns true if a new requestdl call is permitted for this
+// file key. Returns false when the file is within its post-404 cooldown window.
+func (s *Service) refetchAllowed(fileKey string) bool {
+	if until, ok := s.refetchCooldowns.Load(fileKey); ok {
+		return time.Now().After(until)
+	}
+	return true
+}
+
+func (s *Service) setRefetchCooldown(fileKey string) {
+	s.refetchCooldowns.Store(fileKey, time.Now().Add(refetchCooldownDuration))
 }
 
 func (s *Service) handleBadLink(ctx context.Context, err error, entry *storage.Entry, dl types.DownloadLink, attempt int) (types.DownloadLink, error) {


### PR DESCRIPTION
## Problem

Two commits together cause unbounded `requestdl` API calls that can trigger TorBox's `cooldown_until` mechanism:

1. **`4a7777c` (already in beta via this PR)** — CDN 404 was changed from `CategoryPermanent` to `CategoryRefetchable` so that expired CDN URLs are re-fetched rather than cached as permanent failures. This is the correct behaviour for a stale URL, but it has a side-effect:

2. **The loop**: `invalidateAndRefetch` deletes the link from the account-level cache and calls `requestdl` to get a fresh CDN URL. The new URL is returned but **not stored in `s.validated`**. On the next rclone/Plex poll (every few seconds), `s.validated` has no entry → HEAD check → 404 → another `invalidateAndRefetch` → another `requestdl` call. This repeats on every poll for as long as the file returns 404 — which can be minutes while TorBox is still processing a newly-added torrent.

The result is hundreds of `requestdl` calls per file per hour. TorBox's API terms treat this as automated abuse and apply an extended `cooldown_until` freeze on the API key.

## Fix

**`pkg/manager/link/errors.go`** — no change from what landed in beta; 404 stays `CategoryRefetchable`.

**`pkg/manager/link/service.go`** — adds a per-file refetch cooldown map:

- After any 404-triggered `invalidateAndRefetch`, the file key (`infohash:filename`) is recorded with a 5-minute expiry.
- Subsequent polls within that window return the cached error immediately without calling `requestdl`.
- On a successful HEAD validation the cooldown is cleared, so a file that becomes available within the window is served promptly.

The cooldown is intentionally short (5 min) — long enough to stop the flood, short enough that a newly-processed torrent is retried automatically.

## Also included

- Exponential backoff for transient errors (429, 502, 503, 504) during link validation — prevents a single rate-limit spike from being cached as a permanent failure.
- 502/504 added as `CategoryRetryable` (previously fell through to `CategoryPermanent`).
- Retryable errors are no longer stored in `s.validated` — a 502 that clears after 10 s would otherwise block a file for the lifetime of the process.

## Reproducer

1. Add a torrent to TorBox that takes > 30 s to process.
2. Radarr/Sonarr immediately requests the file via the rclone FUSE mount.
3. Without this fix: `requestdl` is called every few seconds until TorBox finishes processing.
4. With this fix: one `requestdl` call on first 404, then silence for 5 min, then one retry.

## Testing

Confirmed against a live TorBox Pro account. The `cooldown_until` field in `/v1/api/user/me` was set by the pre-fix behaviour and expired after the fix was deployed.