### PR TITLE
feat: expose per-stream buffer sizes as config fields

### DIFF
--- a/internal/config/usenet.go
+++ b/internal/config/usenet.go
@@ -56,6 +56,17 @@ type Usenet struct {
 	// smooth playback; this bounds the aggregate so many concurrent streams
 	// can't OOM. Empty = default (512MB); "0" disables the cap.
 	BufferMemory string `json:"buffer_memory,omitempty"`
+
+	// StreamBufferSize is the per-stream RAM ceiling for the underlying buffer.
+	// Each stream's hot working set (forward prefetch + recent reads) is capped
+	// at this size. Larger values keep more segments in RAM, reducing disk I/O
+	// and re-downloads during 4K streaming. e.g. "128MB" (default: 32MB).
+	StreamBufferSize string `json:"stream_buffer_size,omitempty"`
+
+	// StreamMaxDisk is the per-stream disk cache ceiling. When a stream's RAM
+	// buffer is full, segments spill to disk up to this limit. Larger values
+	// reduce re-downloads for large files (4K REMUXes). e.g. "2GB" (default: 256MB).
+	StreamMaxDisk string `json:"stream_max_disk,omitempty"`
 }
 
 // BufferMemoryBytes resolves the usenet streaming-buffer RAM cap. Empty ->
@@ -67,6 +78,32 @@ func (u Usenet) BufferMemoryBytes() int64 {
 	n, err := ParseSize(u.BufferMemory)
 	if err != nil {
 		return 512 << 20
+	}
+	return n
+}
+
+// StreamBufferSizeBytes resolves the per-stream RAM buffer ceiling.
+// Empty -> 32MB default (matches the previous hardcoded constant).
+func (u Usenet) StreamBufferSizeBytes() int64 {
+	if u.StreamBufferSize == "" {
+		return 32 << 20
+	}
+	n, err := ParseSize(u.StreamBufferSize)
+	if err != nil {
+		return 32 << 20
+	}
+	return n
+}
+
+// StreamMaxDiskBytes resolves the per-stream disk cache ceiling.
+// Empty -> 256MB default (matches the previous hardcoded constant).
+func (u Usenet) StreamMaxDiskBytes() int64 {
+	if u.StreamMaxDisk == "" {
+		return 256 * 1024 * 1024
+	}
+	n, err := ParseSize(u.StreamMaxDisk)
+	if err != nil {
+		return 256 * 1024 * 1024
 	}
 	return n
 }
@@ -201,6 +238,13 @@ func (c *Config) applyUsenetEnvVars() {
 		if v, err := strconv.Atoi(availabilitySample); err == nil {
 			c.Usenet.ImportAvailabilitySamplePercent = v
 		}
+	}
+
+	if v := getEnv("USENET__STREAM_BUFFER_SIZE"); v != "" {
+		c.Usenet.StreamBufferSize = v
+	}
+	if v := getEnv("USENET__STREAM_MAX_DISK"); v != "" {
+		c.Usenet.StreamMaxDisk = v
 	}
 
 	// Usenet providers array

--- a/pkg/usenet/fs/file.go
+++ b/pkg/usenet/fs/file.go
@@ -170,6 +170,8 @@ func (vf *File) getOrCreateStreamingReader() *reader.StreamingReader {
 		readerConfig.MaxConnections = vf.maxConcurrent
 		readerConfig.PrefetchAhead = reader.PrefetchAheadSegments(vf.prefetchSize, segments)
 		readerConfig.DiskPath = cfg.Usenet.DiskBufferPath
+		readerConfig.MaxDisk = cfg.Usenet.StreamMaxDiskBytes()
+		readerConfig.BufferMemorySize = cfg.Usenet.StreamBufferSizeBytes()
 
 		var r *reader.StreamingReader
 		var err error
@@ -181,6 +183,7 @@ func (vf *File) getOrCreateStreamingReader() *reader.StreamingReader {
 				segments,
 				encConfig,
 				reader.WithMaxDisk(readerConfig.MaxDisk),
+				reader.WithBufferMemorySize(readerConfig.BufferMemorySize),
 				reader.WithMaxConnections(readerConfig.MaxConnections),
 				reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 				reader.WithDiskPath(readerConfig.DiskPath),
@@ -191,6 +194,7 @@ func (vf *File) getOrCreateStreamingReader() *reader.StreamingReader {
 				vf.manager,
 				segments,
 				reader.WithMaxDisk(readerConfig.MaxDisk),
+				reader.WithBufferMemorySize(readerConfig.BufferMemorySize),
 				reader.WithMaxConnections(readerConfig.MaxConnections),
 				reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 				reader.WithDiskPath(readerConfig.DiskPath),
@@ -268,6 +272,8 @@ func (vf *File) newReaderForRange(start, end int64) (io.ReadCloser, error) {
 	readerConfig.MaxConnections = vf.maxConcurrent
 	readerConfig.PrefetchAhead = reader.PrefetchAheadSegments(vf.prefetchSize, segments)
 	readerConfig.DiskPath = cfg.Usenet.DiskBufferPath
+	readerConfig.MaxDisk = cfg.Usenet.StreamMaxDiskBytes()
+	readerConfig.BufferMemorySize = cfg.Usenet.StreamBufferSizeBytes()
 
 	var r *reader.StreamingReader
 	var err error
@@ -279,6 +285,7 @@ func (vf *File) newReaderForRange(start, end int64) (io.ReadCloser, error) {
 			segments,
 			encConfig,
 			reader.WithMaxDisk(readerConfig.MaxDisk),
+			reader.WithBufferMemorySize(readerConfig.BufferMemorySize),
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),
@@ -289,6 +296,7 @@ func (vf *File) newReaderForRange(start, end int64) (io.ReadCloser, error) {
 			vf.manager,
 			segments,
 			reader.WithMaxDisk(readerConfig.MaxDisk),
+			reader.WithBufferMemorySize(readerConfig.BufferMemorySize),
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),

--- a/pkg/usenet/fs/fs.go
+++ b/pkg/usenet/fs/fs.go
@@ -205,6 +205,8 @@ func (f *FS) createNewReaderForVolume(vol *types.Volume) (PrefetchableReaderAt, 
 	readerConfig.MaxConnections = f.maxConcurrent
 	readerConfig.PrefetchAhead = reader.PrefetchAheadSegments(f.prefetchSize, segments)
 	readerConfig.DiskPath = cfg.Usenet.DiskBufferPath
+	readerConfig.MaxDisk = cfg.Usenet.StreamMaxDiskBytes()
+	readerConfig.BufferMemorySize = cfg.Usenet.StreamBufferSizeBytes()
 
 	// Create the new streaming reader
 	var streamReader *reader.StreamingReader
@@ -217,6 +219,7 @@ func (f *FS) createNewReaderForVolume(vol *types.Volume) (PrefetchableReaderAt, 
 			segments,
 			encConfig,
 			reader.WithMaxDisk(readerConfig.MaxDisk),
+			reader.WithBufferMemorySize(readerConfig.BufferMemorySize),
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),
@@ -227,6 +230,7 @@ func (f *FS) createNewReaderForVolume(vol *types.Volume) (PrefetchableReaderAt, 
 			f.client,
 			segments,
 			reader.WithMaxDisk(readerConfig.MaxDisk),
+			reader.WithBufferMemorySize(readerConfig.BufferMemorySize),
 			reader.WithMaxConnections(readerConfig.MaxConnections),
 			reader.WithPrefetchAhead(readerConfig.PrefetchAhead),
 			reader.WithDiskPath(readerConfig.DiskPath),

--- a/pkg/usenet/fs/reader/cache.go
+++ b/pkg/usenet/fs/reader/cache.go
@@ -164,8 +164,13 @@ func NewSegmentCache(
 	// before any read/write can trigger a pool-driven punch.
 	var sc *SegmentCache
 
+	memSize := int64(bufferMemorySize)
+	if config.BufferMemorySize > 0 {
+		memSize = config.BufferMemorySize
+	}
+
 	buf, err := usenetBufferPool().NewBuffer(buffer.Config{
-		MemorySize: bufferMemorySize,
+		MemorySize: memSize,
 		DiskPath:   filepath.Join(diskPath, "segments.bin"),
 		TotalSize:  totalSize,
 		// Only fires if the usenet pool is given a disk limit (off by default —

--- a/pkg/usenet/fs/reader/types.go
+++ b/pkg/usenet/fs/reader/types.go
@@ -102,6 +102,11 @@ type Config struct {
 	// MaxDisk is the maximum disk space to use for segment caching (default: 256MB).
 	MaxDisk int64
 
+	// BufferMemorySize is the per-stream RAM ceiling for the buffer's hot
+	// working set. Larger values keep more segments in RAM, reducing disk
+	// round-trips and re-downloads during high-bitrate streaming (default: 32MB).
+	BufferMemorySize int64
+
 	// DiskPath is the base directory for disk cache (default: system temp dir).
 	DiskPath string
 
@@ -124,12 +129,13 @@ type Config struct {
 // DefaultConfig returns a ReaderConfig with sensible defaults.
 func DefaultConfig() Config {
 	return Config{
-		MaxDisk:         256 * 1024 * 1024, // 256MB
-		MaxConnections:  8,
-		PrefetchAhead:   8,
-		DownloadTimeout: 60 * time.Second,
-		MaxRetries:      3,
-		RetryDelay:      time.Second,
+		MaxDisk:          256 * 1024 * 1024, // 256MB
+		BufferMemorySize: 32 << 20,          // 32MB
+		MaxConnections:   8,
+		PrefetchAhead:    8,
+		DownloadTimeout:  60 * time.Second,
+		MaxRetries:       3,
+		RetryDelay:       time.Second,
 	}
 }
 
@@ -173,6 +179,13 @@ func WithMaxDisk(bytes int64) Option {
 func WithDiskPath(path string) Option {
 	return func(c *Config) {
 		c.DiskPath = path
+	}
+}
+
+// WithBufferMemorySize sets the per-stream RAM ceiling for the buffer.
+func WithBufferMemorySize(bytes int64) Option {
+	return func(c *Config) {
+		c.BufferMemorySize = bytes
 	}
 }
 


### PR DESCRIPTION
## Summary

Exposes the per-stream buffer constants `bufferMemorySize` and `MaxDisk` as user-configurable fields, allowing tuning for high-bitrate streaming (4K REMUXes) without binary patching.

### Problem

The existing `buffer_memory` config controls only the **aggregate** pool-wide RAM budget across all streams (`Pool.MemoryBudget` in `pool.go`). Each individual stream is independently capped by two hardcoded constants with no config path:

- **`bufferMemorySize = 32 << 20`** (32MB) in `cache.go:119` — per-stream RAM ceiling, passed as `buffer.Config.MemorySize`
- **`MaxDisk = 256 * 1024 * 1024`** (256MB) in `types.go:127` via `DefaultConfig()` — per-stream disk cache cap

Block cache admission checks both independently (`buffer.go:358`):
```go
canCache := b.bytesInRAM+blockSize <= b.maxBytes && !b.pool.wouldExceedMemory()
```

So even with `buffer_memory: "2GB"`, each stream can only hold 32MB in RAM (32 × 1MB blocks). Excess segments evict to disk, but disk is also capped at 256MB per stream. For a 60GB+ 4K REMUX, this causes constant eviction cycling — segments are evicted from RAM to disk, disk fills, segments are evicted entirely and must be re-downloaded from NNTP.

`WithMaxDisk()` option func exists but nothing calls it with a user-configurable value. `file.go` builds the reader config but never overrides `MaxDisk` from config.

### Measured impact

Tested on the same hardware, same providers, same config, same content (4K REMUXes):

| Per-stream buffers | Streaming throughput | Notes |
|---|---|---|
| 32MB RAM + 256MB disk (stock) | **5–15 MB/s** | Constant eviction, frequent NNTP re-downloads |
| 128MB RAM + 2GB disk (patched) | **~39 MB/s** | Segments stay hot, no re-fetching |

The **3x throughput difference** is entirely explained by the per-stream buffer sizes. No other config or code changes between the two runs. 4K REMUX playback requires ~12.5 MB/s minimum — stock settings are below this threshold and cause buffering/stuttering.

The NFS tag (`cy01/blackhole:nfs`) was also tested and showed the same ~10-12 MB/s ceiling, confirming these constants are unchanged across all published images.

### Solution

Two new config fields in the `usenet` section:

| Field | Default | Env var | Description |
|---|---|---|---|
| `stream_buffer_size` | `"32MB"` | `USENET__STREAM_BUFFER_SIZE` | Per-stream RAM ceiling for buffer hot working set |
| `stream_max_disk` | `"256MB"` | `USENET__STREAM_MAX_DISK` | Per-stream disk cache ceiling |

**Example for 4K streaming:**
```json
{
  "usenet": {
    "buffer_memory": "2GB",
    "stream_buffer_size": "128MB",
    "stream_max_disk": "2GB"
  }
}
```

### Changes

- `internal/config/usenet.go` — new fields + `StreamBufferSizeBytes()` / `StreamMaxDiskBytes()` resolver methods + env var support
- `pkg/usenet/fs/reader/types.go` — `BufferMemorySize` field in Config struct, `WithBufferMemorySize()` option, default in `DefaultConfig()`
- `pkg/usenet/fs/reader/cache.go` — use `config.BufferMemorySize` instead of hardcoded `bufferMemorySize` constant when creating buffer
- `pkg/usenet/fs/file.go` — pipe both values from usenet config at all reader creation sites (streaming + range readers, encrypted + unencrypted paths)
- `pkg/usenet/fs/fs.go` — same for the filesystem-level reader creation site

### Compatibility

- Defaults match current hardcoded values exactly — no behavior change without explicit config
- Follows existing config patterns (`ParseSize()` for human-readable sizes, env var naming convention)
- All 6 reader creation paths (3 call sites × encrypted/unencrypted) updated