### PR TITLE
fix(mount): keep Hanwen file identity stable

### DIFF
--- a/pkg/mount/dfs/backend/hanwen/dir.go
+++ b/pkg/mount/dfs/backend/hanwen/dir.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"path"
 	"syscall"
+	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -83,7 +84,11 @@ func (d *Dir) newNode(info *manager.FileInfo) fs.InodeEmbedder {
 
 	var node fs.InodeEmbedder
 	if info.IsDir() {
-		node = newDir(d.vfs, info.Name(), d.childPath(info.Name()), d.level+1, uint64(info.ModTime().Unix()), d.config, d.logger, d.rlLogger)
+		modTime := info.ModTime()
+		if modTime.IsZero() {
+			modTime = time.Now()
+		}
+		node = newDir(d.vfs, info.Name(), d.childPath(info.Name()), d.level+1, uint64(modTime.Unix()), d.config, d.logger, d.rlLogger)
 	} else {
 		node = NewFile(d.vfs, d.config, info, d.rlLogger)
 	}
@@ -114,15 +119,58 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		return nil, errno
 	}
 
+	// Stable attributes make go-fuse retain an existing inode. Refresh the
+	// retained file node before returning it so replacements do not continue
+	// serving stale size and stream metadata.
+	if child, file := d.refreshExistingFile(name, info); child != nil {
+		d.setEntryOut(info, out, uint64(file.modTime(info).Unix()))
+		return child, 0
+	}
+
 	// get or create fuse node (cached on FileInfo)
 	node := d.newNode(info)
 
 	// Set attributes
-	d.setEntryOut(info, out)
+	d.setEntryOut(info, out, d.nodeModTime(info, node))
 
 	// Supplying a stable inode lets NewInode deduplicate repeated lookups.
 	// Leaving Ino unset makes go-fuse allocate a new sequential inode each time.
 	return d.NewInode(ctx, node, d.childStableAttr(name, out.Mode)), 0
+}
+
+func (d *Dir) refreshExistingFile(name string, info *manager.FileInfo) (*fs.Inode, *File) {
+	if info.IsDir() {
+		return nil, nil
+	}
+
+	child := d.GetChild(name)
+	if child == nil {
+		return nil, nil
+	}
+
+	file, ok := child.Operations().(*File)
+	if !ok {
+		return nil, nil
+	}
+
+	file.updateInfo(info)
+	info.SetSys(file)
+	return child, file
+}
+
+func (d *Dir) nodeModTime(info *manager.FileInfo, node fs.InodeEmbedder) uint64 {
+	if modTime := info.ModTime(); !modTime.IsZero() {
+		return uint64(modTime.Unix())
+	}
+
+	switch node := node.(type) {
+	case *File:
+		return uint64(node.createdAt.Unix())
+	case *Dir:
+		return node.modTime
+	default:
+		return 0
+	}
 }
 
 // lookupChild looks up a child by name using O(1) lookups where possible
@@ -161,9 +209,7 @@ func (d *Dir) lookupChild(name string) (*manager.FileInfo, syscall.Errno) {
 }
 
 // setEntryOut sets the attributes for an entry
-func (d *Dir) setEntryOut(info *manager.FileInfo, out *fuse.EntryOut) {
-	modTime := uint64(info.ModTime().Unix())
-
+func (d *Dir) setEntryOut(info *manager.FileInfo, out *fuse.EntryOut, modTime uint64) {
 	if info.IsDir() {
 		out.Attr.Mode = fuse.S_IFDIR | 0755
 		out.Attr.Nlink = 2

--- a/pkg/mount/dfs/backend/hanwen/dir.go
+++ b/pkg/mount/dfs/backend/hanwen/dir.go
@@ -4,6 +4,7 @@ package hanwen
 
 import (
 	"context"
+	"path"
 	"syscall"
 
 	"github.com/hanwen/go-fuse/v2/fs"
@@ -26,13 +27,16 @@ const (
 // Dir implements a FUSE directory following
 type Dir struct {
 	fs.Inode
-	vfs      *vfs.Manager
-	level    DirLevel
-	name     string
-	config   *config.FuseConfig
-	logger   zerolog.Logger
-	rlLogger *logger.RateLimitedLogger
-	modTime  uint64
+	vfs   *vfs.Manager
+	level DirLevel
+	name  string
+	// virtualPath is the canonical path of this directory within the mount.
+	// It is used to give children stable, namespace-unique inode numbers.
+	virtualPath string
+	config      *config.FuseConfig
+	logger      zerolog.Logger
+	rlLogger    *logger.RateLimitedLogger
+	modTime     uint64
 }
 
 var _ = (fs.NodeLookuper)((*Dir)(nil))
@@ -43,14 +47,30 @@ var _ = (fs.NodeRmdirer)((*Dir)(nil))
 
 // NewDir creates a new directory
 func NewDir(vfsManager *vfs.Manager, name string, level DirLevel, modTime uint64, config *config.FuseConfig, log zerolog.Logger, rl *logger.RateLimitedLogger) *Dir {
+	return newDir(vfsManager, name, path.Join("/", name), level, modTime, config, log, rl)
+}
+
+func newDir(vfsManager *vfs.Manager, name, virtualPath string, level DirLevel, modTime uint64, config *config.FuseConfig, log zerolog.Logger, rl *logger.RateLimitedLogger) *Dir {
 	return &Dir{
-		vfs:      vfsManager,
-		name:     name,
-		level:    level,
-		config:   config,
-		logger:   log.With().Str("dir", name).Logger(),
-		rlLogger: rl,
-		modTime:  modTime,
+		vfs:         vfsManager,
+		name:        name,
+		virtualPath: virtualPath,
+		level:       level,
+		config:      config,
+		logger:      log.With().Str("dir", name).Logger(),
+		rlLogger:    rl,
+		modTime:     modTime,
+	}
+}
+
+func (d *Dir) childPath(name string) string {
+	return path.Join(d.virtualPath, name)
+}
+
+func (d *Dir) childStableAttr(name string, mode uint32) fs.StableAttr {
+	return fs.StableAttr{
+		Mode: mode,
+		Ino:  hashPath(d.childPath(name)),
 	}
 }
 
@@ -63,7 +83,7 @@ func (d *Dir) newNode(info *manager.FileInfo) fs.InodeEmbedder {
 
 	var node fs.InodeEmbedder
 	if info.IsDir() {
-		node = NewDir(d.vfs, info.Name(), d.level+1, uint64(info.ModTime().Unix()), d.config, d.logger, d.rlLogger)
+		node = newDir(d.vfs, info.Name(), d.childPath(info.Name()), d.level+1, uint64(info.ModTime().Unix()), d.config, d.logger, d.rlLogger)
 	} else {
 		node = NewFile(d.vfs, d.config, info, d.rlLogger)
 	}
@@ -100,8 +120,9 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 	// Set attributes
 	d.setEntryOut(info, out)
 
-	// Create/get inode - NewInode handles deduplication
-	return d.NewInode(ctx, node, fs.StableAttr{Mode: out.Attr.Mode}), 0
+	// Supplying a stable inode lets NewInode deduplicate repeated lookups.
+	// Leaving Ino unset makes go-fuse allocate a new sequential inode each time.
+	return d.NewInode(ctx, node, d.childStableAttr(name, out.Mode)), 0
 }
 
 // lookupChild looks up a child by name using O(1) lookups where possible
@@ -177,7 +198,7 @@ func (d *Dir) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 		fuseEntries = append(fuseEntries, fuse.DirEntry{
 			Mode: mode,
 			Name: info.Name(),
-			Ino:  hashPath(d.name + "/" + info.Name()),
+			Ino:  d.childStableAttr(info.Name(), mode).Ino,
 		})
 	}
 

--- a/pkg/mount/dfs/backend/hanwen/dir_test.go
+++ b/pkg/mount/dfs/backend/hanwen/dir_test.go
@@ -1,0 +1,50 @@
+//go:build linux || (darwin && amd64)
+
+package hanwen
+
+import (
+	"testing"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/rs/zerolog"
+)
+
+func TestChildStableAttrIsDeterministic(t *testing.T) {
+	dir := &Dir{virtualPath: "/__all__/example"}
+
+	first := dir.childStableAttr("video.mkv", fuse.S_IFREG|0644)
+	second := dir.childStableAttr("video.mkv", fuse.S_IFREG|0644)
+
+	if first != second {
+		t.Fatalf("same child returned different stable attributes: first=%+v second=%+v", first, second)
+	}
+	if first.Ino <= 1 {
+		t.Fatalf("child inode must not use a reserved value: %d", first.Ino)
+	}
+}
+
+func TestChildStableAttrIncludesFullParentPath(t *testing.T) {
+	firstParent := &Dir{virtualPath: "/__all__/example"}
+	secondParent := &Dir{virtualPath: "/provider/example"}
+
+	first := firstParent.childStableAttr("video.mkv", fuse.S_IFREG|0644)
+	second := secondParent.childStableAttr("video.mkv", fuse.S_IFREG|0644)
+
+	if first.Ino == second.Ino {
+		t.Fatalf("same child name under different parents returned inode %d", first.Ino)
+	}
+}
+
+func TestNewDirTracksCanonicalVirtualPath(t *testing.T) {
+	dir := NewDir(nil, "", LevelRoot, 0, nil, zerolog.Nop(), nil)
+
+	if got := dir.childPath("__all__"); got != "/__all__" {
+		t.Fatalf("root child path = %q, want %q", got, "/__all__")
+	}
+
+	group := newDir(nil, "__all__", dir.childPath("__all__"), LevelTorrent, 0, nil, zerolog.Nop(), nil)
+	child := newDir(nil, "example", group.childPath("example"), LevelFile, 0, nil, zerolog.Nop(), nil)
+	if got := child.childPath("video.mkv"); got != "/__all__/example/video.mkv" {
+		t.Fatalf("nested child path = %q, want %q", got, "/__all__/example/video.mkv")
+	}
+}

--- a/pkg/mount/dfs/backend/hanwen/dir_test.go
+++ b/pkg/mount/dfs/backend/hanwen/dir_test.go
@@ -3,10 +3,18 @@
 package hanwen
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/rs/zerolog"
+	internalconfig "github.com/sirrobot01/decypharr/internal/config"
+	"github.com/sirrobot01/decypharr/internal/logger"
+	"github.com/sirrobot01/decypharr/pkg/manager"
+	mountconfig "github.com/sirrobot01/decypharr/pkg/mount/dfs/config"
+	"github.com/sirrobot01/decypharr/pkg/storage"
 )
 
 func TestChildStableAttrIsDeterministic(t *testing.T) {
@@ -47,4 +55,102 @@ func TestNewDirTracksCanonicalVirtualPath(t *testing.T) {
 	if got := child.childPath("video.mkv"); got != "/__all__/example/video.mkv" {
 		t.Fatalf("nested child path = %q, want %q", got, "/__all__/example/video.mkv")
 	}
+}
+
+func TestRefreshExistingFileUpdatesRetainedInode(t *testing.T) {
+	initial := testRemoteFileInfo(t, 128, time.Now().Add(-time.Hour))
+	replacement := testRemoteFileInfo(t, 256, time.Now())
+	root := NewDir(nil, "", LevelRoot, 0, &mountconfig.FuseConfig{}, zerolog.Nop(), logger.NewRateLimitedLogger())
+	file := NewFile(nil, &mountconfig.FuseConfig{}, initial, logger.NewRateLimitedLogger())
+
+	fs.NewNodeFS(root, &fs.Options{})
+	inode := root.NewInode(context.Background(), file, root.childStableAttr("video.mkv", fuse.S_IFREG|0644))
+	if !root.AddChild("video.mkv", inode, false) {
+		t.Fatal("failed to add test child")
+	}
+
+	retained, retainedFile := root.refreshExistingFile("video.mkv", replacement)
+	if retained != inode {
+		t.Fatal("lookup did not return the retained inode")
+	}
+	if retainedFile != file {
+		t.Fatal("lookup did not return the retained file operations")
+	}
+	if got := file.info.Load(); got != replacement {
+		t.Fatal("retained file metadata was not refreshed")
+	}
+
+	var current fuse.AttrOut
+	if errno := file.Getattr(context.Background(), nil, &current); errno != 0 {
+		t.Fatalf("Getattr failed: %v", errno)
+	}
+	if current.Size != uint64(replacement.Size()) {
+		t.Fatalf("current inode size = %d, want replacement size %d", current.Size, replacement.Size())
+	}
+
+	var openSnapshot fuse.AttrOut
+	handle := &Handle{file: file, info: initial, content: initial.Content()}
+	if errno := file.Getattr(context.Background(), handle, &openSnapshot); errno != 0 {
+		t.Fatalf("handle Getattr failed: %v", errno)
+	}
+	if openSnapshot.Size != uint64(initial.Size()) {
+		t.Fatalf("open handle size = %d, want original size %d", openSnapshot.Size, initial.Size())
+	}
+}
+
+func TestSetEntryOutUsesFileTimestampFallback(t *testing.T) {
+	info := &manager.FileInfo{}
+	mountConfig := &mountconfig.FuseConfig{}
+	dir := &Dir{config: mountConfig}
+	file := NewFile(nil, mountConfig, info, logger.NewRateLimitedLogger())
+
+	var entry fuse.EntryOut
+	dir.setEntryOut(info, &entry, dir.nodeModTime(info, file))
+
+	var attr fuse.AttrOut
+	if errno := file.Getattr(context.Background(), nil, &attr); errno != 0 {
+		t.Fatalf("Getattr failed: %v", errno)
+	}
+	if entry.Mtime != attr.Mtime || entry.Ctime != attr.Ctime || entry.Atime != attr.Atime {
+		t.Fatalf("entry timestamps (%d, %d, %d) differ from Getattr (%d, %d, %d)", entry.Atime, entry.Mtime, entry.Ctime, attr.Atime, attr.Mtime, attr.Ctime)
+	}
+	if entry.Mtime > uint64(time.Now().Add(time.Minute).Unix()) {
+		t.Fatalf("zero ModTime underflowed to %d", entry.Mtime)
+	}
+}
+
+func testRemoteFileInfo(t *testing.T, size int64, addedOn time.Time) *manager.FileInfo {
+	t.Helper()
+	internalconfig.SetConfigPath(t.TempDir())
+	internalconfig.Reset()
+	managerInstance := manager.New()
+	defer func() {
+		if err := managerInstance.Stop(); err != nil {
+			t.Errorf("stop manager: %v", err)
+		}
+		internalconfig.Reset()
+	}()
+
+	entry := &storage.Entry{
+		Protocol: internalconfig.ProtocolTorrent,
+		InfoHash: "test-hash",
+		Name:     "test-entry",
+		Size:     size,
+		Files: map[string]*storage.File{
+			"video.mkv": {
+				Name:     "video.mkv",
+				Size:     size,
+				InfoHash: "test-hash",
+				AddedOn:  addedOn,
+			},
+		},
+	}
+	if err := managerInstance.Storage().AddOrUpdate(entry); err != nil {
+		t.Fatalf("add test entry: %v", err)
+	}
+	info, err := managerInstance.GetTorrentFile(entry.Name, "video.mkv")
+	if err != nil {
+		t.Fatalf("get test file metadata: %v", err)
+	}
+	return info
 }

--- a/pkg/mount/dfs/backend/hanwen/file.go
+++ b/pkg/mount/dfs/backend/hanwen/file.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -23,9 +24,8 @@ type File struct {
 	fs.Inode
 	config    *config.FuseConfig
 	logger    *logger.RateLimitedEvent
-	info      *manager.FileInfo
+	info      atomic.Pointer[manager.FileInfo]
 	createdAt time.Time
-	content   []byte // For files like version.txt
 	vfs       *vfs.Manager
 }
 
@@ -43,24 +43,47 @@ func NewFile(vfsManager *vfs.Manager, config *config.FuseConfig, info *manager.F
 		createdAt = time.Now()
 	}
 
-	return &File{
+	file := &File{
 		config:    config,
 		logger:    rl.Rate(fmt.Sprintf("%s/%s", info.Parent(), info.Name())),
-		info:      info,
 		vfs:       vfsManager,
-		content:   info.Content(),
 		createdAt: createdAt,
 	}
+	file.info.Store(info)
+	return file
+}
+
+func (f *File) updateInfo(info *manager.FileInfo) {
+	f.info.Store(info)
+}
+
+func (f *File) modTime(info *manager.FileInfo) time.Time {
+	if modTime := info.ModTime(); !modTime.IsZero() {
+		return modTime
+	}
+	return f.createdAt
+}
+
+func (f *File) infoForHandle(fh fs.FileHandle) *manager.FileInfo {
+	if handle, ok := fh.(*Handle); ok && handle.info != nil {
+		return handle.info
+	}
+	return f.info.Load()
 }
 
 // Getattr returns file attributes
 func (f *File) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	modTime := uint64(f.createdAt.Unix())
+	info := f.infoForHandle(fh)
+	if info == nil {
+		return syscall.EIO
+	}
+
+	modTime := uint64(f.modTime(info).Unix())
 	out.Mode = 0644 | fuse.S_IFREG
-	out.Size = uint64(f.info.Size())
+	out.Size = uint64(info.Size())
 	out.Nlink = 1 // Files always have 1 link (themselves)
 	out.Blksize = 4096
-	out.Blocks = (uint64(f.info.Size()) + 511) / 512 // Number of 512-byte blocks
+	out.Blocks = (uint64(info.Size()) + 511) / 512 // Number of 512-byte blocks
 	out.Uid = f.config.UID
 	out.Gid = f.config.GID
 	out.Atime = modTime
@@ -73,19 +96,26 @@ func (f *File) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut)
 // Open creates file handle with VFS or DFS based on configuration
 // Reader is created eagerly here instead of lazily in Read() to surface errors early
 func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	info := f.info.Load()
+	if info == nil {
+		return nil, 0, syscall.EIO
+	}
+	content := info.Content()
 
 	var reader *vfs.StreamingFile
-	if f.info.IsRemote() && len(f.content) == 0 {
+	if info.IsRemote() && len(content) == 0 {
 		var err error
-		reader, err = f.vfs.GetFile(f.info)
+		reader, err = f.vfs.GetFile(info)
 		if err != nil {
-			f.logger.Error().Err(err).Str("file", f.info.Name()).Msg("Failed to get reader at open")
+			f.logger.Error().Err(err).Str("file", info.Name()).Msg("Failed to get reader at open")
 			return nil, 0, syscall.EIO
 		}
 	}
 
 	fh := &Handle{
 		file:       f,
+		info:       info,
+		content:    content,
 		streamFile: reader,
 		logger:     f.logger,
 	}

--- a/pkg/mount/dfs/backend/hanwen/file.go
+++ b/pkg/mount/dfs/backend/hanwen/file.go
@@ -36,23 +36,26 @@ var (
 
 // NewFile creates a new file
 func NewFile(vfsManager *vfs.Manager, config *config.FuseConfig, info *manager.FileInfo, rl *logger.RateLimitedLogger) *File {
+	createdAt := info.ModTime()
+	if createdAt.IsZero() {
+		// Choose the fallback once when the node is created. Recomputing it in
+		// Getattr would change ctime and mtime whenever the attr cache expires.
+		createdAt = time.Now()
+	}
+
 	return &File{
-		config:  config,
-		logger:  rl.Rate(fmt.Sprintf("%s/%s", info.Parent(), info.Name())),
-		info:    info,
-		vfs:     vfsManager,
-		content: info.Content(),
+		config:    config,
+		logger:    rl.Rate(fmt.Sprintf("%s/%s", info.Parent(), info.Name())),
+		info:      info,
+		vfs:       vfsManager,
+		content:   info.Content(),
+		createdAt: createdAt,
 	}
 }
 
 // Getattr returns file attributes
 func (f *File) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
-	var modTime uint64
-	if f.createdAt.IsZero() {
-		modTime = uint64(time.Now().Unix())
-	} else {
-		modTime = uint64(f.createdAt.Unix())
-	}
+	modTime := uint64(f.createdAt.Unix())
 	out.Mode = 0644 | fuse.S_IFREG
 	out.Size = uint64(f.info.Size())
 	out.Nlink = 1 // Files always have 1 link (themselves)

--- a/pkg/mount/dfs/backend/hanwen/file_test.go
+++ b/pkg/mount/dfs/backend/hanwen/file_test.go
@@ -3,8 +3,12 @@
 package hanwen
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/sirrobot01/decypharr/internal/logger"
 	"github.com/sirrobot01/decypharr/pkg/manager"
 	"github.com/sirrobot01/decypharr/pkg/mount/dfs/config"
@@ -27,4 +31,47 @@ func TestNewFileChoosesStableFallbackTime(t *testing.T) {
 	if file.createdAt.IsZero() {
 		t.Fatal("file timestamp must be initialized when metadata has no modification time")
 	}
+}
+
+func TestHandleKeepsMetadataSnapshot(t *testing.T) {
+	initial := testRemoteFileInfo(t, 128, time.Now().Add(-time.Hour))
+	replacement := testRemoteFileInfo(t, 256, time.Now())
+	file := NewFile(nil, &config.FuseConfig{}, initial, logger.NewRateLimitedLogger())
+	handle := &Handle{file: file, info: initial, content: initial.Content()}
+
+	file.updateInfo(replacement)
+
+	if got := file.infoForHandle(handle); got != initial {
+		t.Fatal("open handle did not retain its original metadata")
+	}
+	if got := file.infoForHandle(nil); got != replacement {
+		t.Fatal("inode did not expose refreshed metadata to new operations")
+	}
+}
+
+func TestFileMetadataRefreshIsRaceSafe(t *testing.T) {
+	first := testRemoteFileInfo(t, 128, time.Now().Add(-time.Hour))
+	second := testRemoteFileInfo(t, 256, time.Now())
+	file := NewFile(nil, &config.FuseConfig{}, first, logger.NewRateLimitedLogger())
+
+	var workers sync.WaitGroup
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		for range 1000 {
+			file.updateInfo(first)
+			file.updateInfo(second)
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		for range 1000 {
+			var out fuse.AttrOut
+			if errno := file.Getattr(context.Background(), nil, &out); errno != 0 {
+				t.Errorf("Getattr failed: %v", errno)
+				return
+			}
+		}
+	}()
+	workers.Wait()
 }

--- a/pkg/mount/dfs/backend/hanwen/file_test.go
+++ b/pkg/mount/dfs/backend/hanwen/file_test.go
@@ -1,0 +1,30 @@
+//go:build linux || (darwin && amd64)
+
+package hanwen
+
+import (
+	"testing"
+
+	"github.com/sirrobot01/decypharr/internal/logger"
+	"github.com/sirrobot01/decypharr/pkg/manager"
+	"github.com/sirrobot01/decypharr/pkg/mount/dfs/config"
+)
+
+func TestNewFileUsesMetadataModificationTime(t *testing.T) {
+	var managerInstance manager.Manager
+	info := managerInstance.RootInfo()
+	file := NewFile(nil, &config.FuseConfig{}, info, &logger.RateLimitedLogger{})
+
+	if !file.createdAt.Equal(info.ModTime()) {
+		t.Fatalf("file timestamp = %v, want metadata timestamp %v", file.createdAt, info.ModTime())
+	}
+}
+
+func TestNewFileChoosesStableFallbackTime(t *testing.T) {
+	info := &manager.FileInfo{}
+	file := NewFile(nil, &config.FuseConfig{}, info, &logger.RateLimitedLogger{})
+
+	if file.createdAt.IsZero() {
+		t.Fatal("file timestamp must be initialized when metadata has no modification time")
+	}
+}

--- a/pkg/mount/dfs/backend/hanwen/handle.go
+++ b/pkg/mount/dfs/backend/hanwen/handle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/sirrobot01/decypharr/internal/logger"
+	"github.com/sirrobot01/decypharr/pkg/manager"
 	"github.com/sirrobot01/decypharr/pkg/mount/dfs/vfs"
 )
 
@@ -25,6 +26,8 @@ var (
 // Handle implements file operations using the new DFS implementation
 type Handle struct {
 	file       *File
+	info       *manager.FileInfo
+	content    []byte
 	streamFile *vfs.StreamingFile
 	closed     atomic.Bool
 	logger     *logger.RateLimitedEvent
@@ -39,7 +42,7 @@ func (fh *Handle) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadRe
 	// Static content (e.g. version.txt): serve from the in-memory buffer.
 	// Check this first — streamFile is nil for static files, so dereferencing
 	// it below would panic.
-	if len(fh.file.content) > 0 {
+	if len(fh.content) > 0 {
 		data := fh.readFromStaticContent(off, int64(len(dest)))
 		return fuse.ReadResultData(data), 0
 	}
@@ -77,7 +80,7 @@ func (fh *Handle) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadRe
 
 // readFromStaticContent handles static content
 func (fh *Handle) readFromStaticContent(offset, size int64) []byte {
-	content := fh.file.content
+	content := fh.content
 	end := offset + size
 	if end > int64(len(content)) {
 		end = int64(len(content))
@@ -97,7 +100,7 @@ func (fh *Handle) Release(ctx context.Context) syscall.Errno {
 	if fh.streamFile != nil {
 		fh.streamFile.Close()
 		if fh.file != nil && fh.file.vfs != nil {
-			fh.file.vfs.ReleaseFile(fh.file.info)
+			fh.file.vfs.ReleaseFile(fh.info)
 		}
 	}
 


### PR DESCRIPTION
## 📌 Description

- Keep Hanwen FUSE identity metadata stable for unchanged files, so applications serving them over HTTP generate consistent ETags across repeated lookups.

The Hanwen `Lookup` path left `StableAttr.Ino` unset. go-fuse therefore allocated a new sequential inode whenever a fresh manager lookup produced a new node. `File.Getattr` also recomputed its fallback timestamp with `time.Now()` because `createdAt` was never initialized, allowing ctime and mtime to change after the attribute cache expired.

Closes #387.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

- Track each Hanwen directory's canonical virtual path and derive stable child inode numbers from the complete path.
- Use the same stable inode identity in both `Lookup` and `Readdir`, while keeping the existing fresh manager lookups and short entry timeout.
- Initialize file timestamps once from metadata, with a one-time fallback when metadata has no modification time.
- Add regression tests for deterministic inode identity, separation across different parent paths, canonical nested paths, metadata timestamps, and stable fallback timestamps.

---

## Testing

- [x] Tested locally

Steps:

1. Ran `go test ./...` in Linux/ARM64: all packages passed.
2. Ran diff-scoped `golangci-lint`: zero issues.
3. Built the repository Docker image successfully for Linux/ARM64.
4. Repeated fresh lookups eight times: inode, device, ctime, mtime, and size remained identical.
5. Repeated the metadata check after the 30-second attribute cache expired: identity and timestamps remained identical.
6. Read 1 MiB ranges from the beginning, middle, and end of a media file: all reads completed and the derived strong ETag remained unchanged.

---

## Risks / Notes

- Existing Hanwen mounts receive new deterministic inode numbers after upgrading and remounting.
- Inodes are scoped by full virtual path, avoiding collisions between identically named children under different directory views.
- Fresh manager lookups and current cache timeouts are unchanged.
- No storage migration, configuration change, or non-Hanwen backend change is included.

---

## Screenshots (if applicable)

Not applicable; this is a filesystem metadata fix.

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct

