### PR TITLE
fix: pass movieId to Radarr manual import

### DIFF
--- a/pkg/arr/import.go
+++ b/pkg/arr/import.go
@@ -62,6 +62,9 @@ type ImportResponseSchema struct {
 		LanguageProfileId int `json:"languageProfileId"`
 		Id                int `json:"id"`
 	} `json:"series"`
+	Movie struct {
+		Id int `json:"id"`
+	} `json:"movie"`
 	SeasonNumber int `json:"seasonNumber"`
 	Episodes     []struct {
 		SeriesId                 int       `json:"seriesId"`
@@ -116,6 +119,7 @@ type ManualImportRequestFile struct {
 	FolderName   string `json:"folderName"`
 	Path         string `json:"path"`
 	SeriesId     int    `json:"seriesId"`
+	MovieId      int    `json:"movieId,omitempty"`
 	SeasonNumber int    `json:"seasonNumber"`
 	EpisodeIds   []int  `json:"episodeIds"`
 	Quality      struct {
@@ -172,6 +176,7 @@ func (a *Arr) Import(downloadID string) error {
 			Path:              d.Path,
 			FolderName:        d.FolderName,
 			SeriesId:          d.Series.Id,
+			MovieId:           d.Movie.Id,
 			SeasonNumber:      d.SeasonNumber,
 			EpisodeIds:        episodesIds,
 			Quality:           d.Quality,


### PR DESCRIPTION
# Pull Request Description

Fixes Radarr manual imports by passing the movie ID returned by Radarr's Manual Import API back to the import request.

Previously, Decypharr populated `seriesId` but did not read or send `movieId`. For Radarr imports, this resulted in ManualImport commands being submitted with `movieId = 0`, preventing the movie from being imported correctly.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

* Read `movie.id` from the Manual Import response.
* Add `movieId` to `ManualImportRequestFile`.
* Pass the returned movie ID to Radarr when performing the import.
* Keep Sonarr behavior unchanged by using `omitempty`.

---

## Testing

* [x] Tested locally

Steps:

1. Built Decypharr v2.5 locally with the patch applied.
2. Re-ran the affected Radarr manual import and confirmed the request used the expected `movieId` instead of `0`.
3. Confirmed the download imported successfully and Radarr created the expected `MovieFile`.

---

## Risks / Notes

* The change only affects the movie ID used for Radarr manual imports.
* `movieId` is omitted when empty, so Sonarr imports remain unchanged.
* No configuration changes or migrations are required.

---

## Screenshots (if applicable)

Not applicable; this is a backend import fix.

---

## Checklist

* [x] Code builds successfully
* [x] No console/log errors
* [x] Reviewed my own code
* [x] Target branch is correct
